### PR TITLE
Page feature build out

### DIFF
--- a/backend/src/lib/config/settings.py
+++ b/backend/src/lib/config/settings.py
@@ -1,3 +1,4 @@
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 import os
 
@@ -6,9 +7,18 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "NoteBud API"
     API_V1_STR: str = "/api/v1"
 
-    NEO4J_URI: str = "bolt://localhost:7687"
-    NEO4J_USERNAME: str = "neo4j"
-    NEO4J_PASSWORD: str = "notebud_password"
+    NEO4J_URI: str = Field(
+        default="bolt://localhost:7687",
+        validation_alias=AliasChoices("NEO4J_URI", "NEO4J_BOLT_URL"),
+    )
+    NEO4J_USERNAME: str = Field(
+        default="neo4j",
+        validation_alias=AliasChoices("NEO4J_USERNAME", "NEO4J_USER"),
+    )
+    NEO4J_PASSWORD: str = Field(
+        default="notebud_password",
+        validation_alias=AliasChoices("NEO4J_PASSWORD", "NEO4J_PASS"),
+    )
 
     GCS_BUCKET_NAME: str = "notebud-dev-bucket"
     GOOGLE_APPLICATION_CREDENTIALS: str = "./service-account-key.json"

--- a/frontend/src/app/backpack/[id]/page.tsx
+++ b/frontend/src/app/backpack/[id]/page.tsx
@@ -286,7 +286,7 @@ export default function NotebookDetailPage() {
                     className="w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
                   >
                     <option value="">Select a course…</option>
-                    {courses.map((c) => (
+                    {courses.filter((c) => c.code !== notebook.course_code).map((c) => (
                       <option key={c.code} value={c.code}>
                         {c.code} — {c.name}
                       </option>

--- a/frontend/src/app/backpack/[id]/page.tsx
+++ b/frontend/src/app/backpack/[id]/page.tsx
@@ -81,13 +81,18 @@ export default function NotebookDetailPage() {
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
-    await updateMutation.mutateAsync({
-      id,
-      title: title.trim(),
-      course_code: courseCode.trim(),
-      description: description.trim() || null,
-    });
-    setIsEditing(false);
+    try {
+      await updateMutation.mutateAsync({
+        id,
+        title: title.trim(),
+        course_code: courseCode.trim(),
+        description: description.trim() || null,
+      });
+      setIsEditing(false);
+    } catch (error) {
+      // Keep isEditing true so the user can correct issues; error state will be reflected via updateMutation.isError
+      console.error('Failed to update notebook:', error);
+    }
   }
 
   return (

--- a/frontend/src/app/backpack/[id]/page.tsx
+++ b/frontend/src/app/backpack/[id]/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { getNotebook } from '../../../lib/api';
+import { useUpdateNotebook } from '../../../hooks/useNotebooks';
+
+export default function NotebookDetailPage() {
+  const { id } = useParams<{ id: string }>();
+
+  const { data: notebook, isLoading, isError } = useQuery({
+    queryKey: ['notebook', id],
+    queryFn: () => getNotebook(id),
+  });
+
+  const updateMutation = useUpdateNotebook();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [title, setTitle] = useState('');
+  const [courseCode, setCourseCode] = useState('');
+  const [description, setDescription] = useState('');
+
+  function startEdit() {
+    if (!notebook) return;
+    setTitle(notebook.title);
+    setCourseCode(notebook.course_code);
+    setDescription(notebook.description ?? '');
+    setIsEditing(true);
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    await updateMutation.mutateAsync({
+      id,
+      title: title.trim(),
+      course_code: courseCode.trim(),
+      description: description.trim() || null,
+    });
+    setIsEditing(false);
+  }
+
+  return (
+    <div className="fixed inset-0 z-0 overflow-hidden">
+      <div className="absolute inset-0 bg-[url('/forest-bg.png')] bg-center bg-cover bg-no-repeat">
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(180,200,190,0.3)_0%,rgba(200,210,200,0.2)_50%,rgba(180,195,185,0.4)_100%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,rgba(220,230,225,0.4)_0%,transparent_60%)]" />
+      </div>
+      <main className="relative z-10 min-h-screen p-6 pt-24 sm:p-8 sm:pt-28">
+        <div className="mx-auto max-w-3xl">
+          <Link
+            href="/backpack"
+            className="mb-6 inline-flex items-center gap-1 text-sm text-slate-600 hover:text-slate-900"
+          >
+            <ArrowLeftIcon className="size-4" />
+            Back to Backpack
+          </Link>
+
+          {isLoading && (
+            <div className="flex min-h-[200px] items-center justify-center">
+              <p className="text-slate-600">Loading notebook…</p>
+            </div>
+          )}
+
+          {isError && (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+              <p className="font-medium text-red-800">Failed to load notebook</p>
+              <p className="mt-1 text-sm text-red-600">Check that the backend is running and try again.</p>
+            </div>
+          )}
+
+          {notebook && (
+            <div className="glass-panel rounded-xl p-6 shadow-sm backdrop-blur-[30px]">
+              {isEditing ? (
+                <form onSubmit={handleSave} className="flex flex-col gap-4">
+                  <div>
+                    <label htmlFor="title" className="mb-1 block text-sm font-medium text-slate-700">
+                      Title
+                    </label>
+                    <input
+                      id="title"
+                      type="text"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      required
+                      className="w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="courseCode" className="mb-1 block text-sm font-medium text-slate-700">
+                      Course code
+                    </label>
+                    <input
+                      id="courseCode"
+                      type="text"
+                      value={courseCode}
+                      onChange={(e) => setCourseCode(e.target.value)}
+                      required
+                      className="w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="description" className="mb-1 block text-sm font-medium text-slate-700">
+                      Description
+                    </label>
+                    <textarea
+                      id="description"
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      rows={3}
+                      className="w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                    />
+                  </div>
+                  {updateMutation.isError && (
+                    <p className="text-sm text-red-600">Failed to save changes. Please try again.</p>
+                  )}
+                  <div className="flex gap-3">
+                    <button
+                      type="submit"
+                      disabled={updateMutation.isPending}
+                      className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                    >
+                      {updateMutation.isPending ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setIsEditing(false)}
+                      className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <>
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <h1 className="text-2xl font-bold text-slate-900">{notebook.title}</h1>
+                      <p className="mt-1 text-sm font-medium text-slate-600">{notebook.course_code}</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={startEdit}
+                      className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                    >
+                      Edit
+                    </button>
+                  </div>
+                  {notebook.description && (
+                    <p className="mt-4 text-sm text-slate-700">{notebook.description}</p>
+                  )}
+                  <p className="mt-4 text-xs text-slate-500">
+                    Created {new Date(notebook.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
+                  </p>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/backpack/[id]/page.tsx
+++ b/frontend/src/app/backpack/[id]/page.tsx
@@ -5,7 +5,15 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { ArrowLeftIcon, DocumentArrowUpIcon } from '@heroicons/react/24/outline';
-import { getNotebook, uploadFile, type UploadFileResponse } from '../../../lib/api';
+import {
+  getNotebook,
+  uploadFile,
+  getCourses,
+  addNotebookTag,
+  removeNotebookTag,
+  type UploadFileResponse,
+  type NotebookTagResponse,
+} from '../../../lib/api';
 import { useUpdateNotebook } from '../../../hooks/useNotebooks';
 
 export default function NotebookDetailPage() {
@@ -38,6 +46,30 @@ export default function NotebookDetailPage() {
     setUploadResult(null);
     uploadMutation.mutate(file);
   }
+
+  const { data: courses = [] } = useQuery({
+    queryKey: ['courses'],
+    queryFn: getCourses,
+  });
+
+  const [tagType, setTagType] = useState<'prerequisite' | 'relates-to'>('prerequisite');
+  const [selectedCourse, setSelectedCourse] = useState('');
+  const [localTags, setLocalTags] = useState<NotebookTagResponse[]>([]);
+
+  const addTagMutation = useMutation({
+    mutationFn: () => addNotebookTag(id, tagType, selectedCourse),
+    onSuccess: (data) => {
+      setLocalTags((prev) => [...prev, data]);
+      setSelectedCourse('');
+    },
+  });
+
+  const removeTagMutation = useMutation({
+    mutationFn: (courseCode: string) => removeNotebookTag(id, courseCode),
+    onSuccess: (_, courseCode) => {
+      setLocalTags((prev) => prev.filter((t) => t.course_code !== courseCode));
+    },
+  });
 
   function startEdit() {
     if (!notebook) return;
@@ -220,6 +252,80 @@ export default function NotebookDetailPage() {
                   <p className="font-medium">{uploadResult.filename}</p>
                   <p className="mt-0.5 text-xs text-emerald-600 break-all">{uploadResult.gcs_uri}</p>
                 </div>
+              )}
+            </div>
+            {/* Course Tags */}
+            <div className="mt-6 glass-panel rounded-xl p-6 shadow-sm backdrop-blur-[30px]">
+              <h2 className="mb-4 text-base font-semibold text-slate-900">Course Tags</h2>
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <div className="flex-1">
+                  <label htmlFor="courseSelect" className="mb-1 block text-sm font-medium text-slate-700">
+                    Course
+                  </label>
+                  <select
+                    id="courseSelect"
+                    value={selectedCourse}
+                    onChange={(e) => setSelectedCourse(e.target.value)}
+                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                  >
+                    <option value="">Select a course…</option>
+                    {courses.map((c) => (
+                      <option key={c.code} value={c.code}>
+                        {c.code} — {c.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="tagType" className="mb-1 block text-sm font-medium text-slate-700">
+                    Type
+                  </label>
+                  <select
+                    id="tagType"
+                    value={tagType}
+                    onChange={(e) => setTagType(e.target.value as 'prerequisite' | 'relates-to')}
+                    className="rounded-md border border-slate-300 px-3 py-2 text-slate-900 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                  >
+                    <option value="prerequisite">Prerequisite</option>
+                    <option value="relates-to">Relates to</option>
+                  </select>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => addTagMutation.mutate()}
+                  disabled={!selectedCourse || addTagMutation.isPending}
+                  className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  {addTagMutation.isPending ? 'Adding…' : 'Add'}
+                </button>
+              </div>
+
+              {addTagMutation.isError && (
+                <p className="mt-2 text-sm text-red-600">Failed to add tag. Please try again.</p>
+              )}
+
+              {localTags.length > 0 && (
+                <ul className="mt-4 flex flex-wrap gap-2">
+                  {localTags.map((tag) => (
+                    <li
+                      key={tag.course_code}
+                      className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-sm text-emerald-800"
+                    >
+                      <span className="capitalize">{tag.type}</span>
+                      <span className="font-medium">{tag.course_code}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeTagMutation.mutate(tag.course_code)}
+                        disabled={removeTagMutation.isPending}
+                        aria-label={`Remove ${tag.course_code}`}
+                        className="ml-1 text-emerald-600 hover:text-emerald-900 disabled:opacity-50"
+                      >
+                        ×
+                      </button>
+                    </li>
+                  ))}
+                </ul>
               )}
             </div>
             </>

--- a/frontend/src/app/backpack/[id]/page.tsx
+++ b/frontend/src/app/backpack/[id]/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
-import { useQuery } from '@tanstack/react-query';
-import { ArrowLeftIcon } from '@heroicons/react/24/outline';
-import { getNotebook } from '../../../lib/api';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { ArrowLeftIcon, DocumentArrowUpIcon } from '@heroicons/react/24/outline';
+import { getNotebook, uploadFile, type UploadFileResponse } from '../../../lib/api';
 import { useUpdateNotebook } from '../../../hooks/useNotebooks';
 
 export default function NotebookDetailPage() {
@@ -22,6 +22,22 @@ export default function NotebookDetailPage() {
   const [title, setTitle] = useState('');
   const [courseCode, setCourseCode] = useState('');
   const [description, setDescription] = useState('');
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [sourceType, setSourceType] = useState<'content' | 'syllabus'>('content');
+  const [uploadResult, setUploadResult] = useState<UploadFileResponse | null>(null);
+
+  const uploadMutation = useMutation({
+    mutationFn: (file: File) => uploadFile(id, file, sourceType),
+    onSuccess: (data) => setUploadResult(data),
+  });
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadResult(null);
+    uploadMutation.mutate(file);
+  }
 
   function startEdit() {
     if (!notebook) return;
@@ -72,6 +88,7 @@ export default function NotebookDetailPage() {
           )}
 
           {notebook && (
+            <>
             <div className="glass-panel rounded-xl p-6 shadow-sm backdrop-blur-[30px]">
               {isEditing ? (
                 <form onSubmit={handleSave} className="flex flex-col gap-4">
@@ -157,6 +174,55 @@ export default function NotebookDetailPage() {
                 </>
               )}
             </div>
+
+            {/* File Upload */}
+            <div className="mt-6 glass-panel rounded-xl p-6 shadow-sm backdrop-blur-[30px]">
+              <h2 className="mb-4 text-base font-semibold text-slate-900">Upload Document</h2>
+
+              <div className="mb-4 flex gap-2">
+                {(['content', 'syllabus'] as const).map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onClick={() => setSourceType(type)}
+                    className={`rounded-lg px-3 py-1.5 text-sm font-medium capitalize transition-colors ${
+                      sourceType === type
+                        ? 'bg-emerald-600 text-white'
+                        : 'border border-slate-300 text-slate-700 hover:bg-slate-50'
+                    }`}
+                  >
+                    {type}
+                  </button>
+                ))}
+              </div>
+
+              <label className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-slate-300 p-8 text-center hover:border-emerald-400 hover:bg-emerald-50/30 transition-colors">
+                <DocumentArrowUpIcon className="mb-2 size-8 text-slate-400" />
+                <span className="text-sm text-slate-600">
+                  {uploadMutation.isPending ? 'Uploading…' : 'Click to select a PDF, DOCX, or PPTX file'}
+                </span>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".pdf,.docx,.pptx"
+                  onChange={handleFileChange}
+                  disabled={uploadMutation.isPending}
+                  className="hidden"
+                />
+              </label>
+
+              {uploadMutation.isError && (
+                <p className="mt-3 text-sm text-red-600">Upload failed. Please try again.</p>
+              )}
+
+              {uploadResult && (
+                <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+                  <p className="font-medium">{uploadResult.filename}</p>
+                  <p className="mt-0.5 text-xs text-emerald-600 break-all">{uploadResult.gcs_uri}</p>
+                </div>
+              )}
+            </div>
+            </>
           )}
         </div>
       </main>

--- a/frontend/src/app/backpack/[id]/page.tsx
+++ b/frontend/src/app/backpack/[id]/page.tsx
@@ -60,7 +60,10 @@ export default function NotebookDetailPage() {
   const addTagMutation = useMutation({
     mutationFn: () => addNotebookTag(id, tagType, selectedCourse),
     onSuccess: (data) => {
-      setLocalTags((prev) => [...prev, data]);
+      setLocalTags((prev) => {
+        const exists = prev.some((t) => t.course_code === data.course_code);
+        return exists ? prev : [...prev, data];
+      });
       setSelectedCourse('');
     },
   });

--- a/frontend/src/app/backpack/[id]/page.tsx
+++ b/frontend/src/app/backpack/[id]/page.tsx
@@ -30,6 +30,7 @@ export default function NotebookDetailPage() {
   const [title, setTitle] = useState('');
   const [courseCode, setCourseCode] = useState('');
   const [description, setDescription] = useState('');
+  const [editValidationError, setEditValidationError] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [sourceType, setSourceType] = useState<'content' | 'syllabus'>('content');
@@ -81,11 +82,18 @@ export default function NotebookDetailPage() {
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
+    const trimmedTitle = title.trim();
+    const trimmedCourseCode = courseCode.trim();
+    if (!trimmedTitle || !trimmedCourseCode) {
+      setEditValidationError('Title and course code cannot be empty.');
+      return;
+    }
+    setEditValidationError(null);
     try {
       await updateMutation.mutateAsync({
         id,
-        title: title.trim(),
-        course_code: courseCode.trim(),
+        title: trimmedTitle,
+        course_code: trimmedCourseCode,
         description: description.trim() || null,
       });
       setIsEditing(false);
@@ -167,6 +175,9 @@ export default function NotebookDetailPage() {
                       className="w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
                     />
                   </div>
+                  {editValidationError && (
+                    <p className="text-sm text-red-600">{editValidationError}</p>
+                  )}
                   {updateMutation.isError && (
                     <p className="text-sm text-red-600">Failed to save changes. Please try again.</p>
                   )}

--- a/frontend/src/app/backpack/page.tsx
+++ b/frontend/src/app/backpack/page.tsx
@@ -16,15 +16,17 @@ export default function BackpackPage() {
     const [showCreateForm, setShowCreateForm] = useState(false);
     const [title, setTitle] = useState('');
     const [courseCode, setCourseCode] = useState('');
+    const [description, setDescription] = useState('');
 
     const handleCreate = async (e: React.FormEvent) => {
         e.preventDefault();
         if (!title.trim() || !courseCode.trim()) return;
 
         try {
-            await createMutation.mutateAsync({ title: title.trim(), course_code: courseCode.trim() });
+            await createMutation.mutateAsync({ title: title.trim(), course_code: courseCode.trim(), description: description.trim() || null });
             setTitle('');
             setCourseCode('');
+            setDescription('');
             setShowCreateForm(false);
         } catch {
             // Error handled by mutation / global error handler
@@ -61,6 +63,19 @@ export default function BackpackPage() {
                             <h2 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">
                                 New notebook
                             </h2>
+                            <div className="mb-3">
+                                    <label htmlFor="description" className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                                        Description <span className="text-slate-400">(optional)</span>
+                                    </label>
+                                    <textarea
+                                        id="description"
+                                        value={description}
+                                        onChange={(e) => setDescription(e.target.value)}
+                                        placeholder="e.g. Notes on cell structure and genetics"
+                                        rows={2}
+                                        className="w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 placeholder-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-500"
+                                    />
+                                </div>
                             <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
                                 <div className="flex-1">
                                     <label htmlFor="title" className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">

--- a/frontend/src/app/courses/page.tsx
+++ b/frontend/src/app/courses/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getCourses } from '../../lib/api';
+
+export default function CoursesPage() {
+  const { data: courses = [], isLoading, isError } = useQuery({
+    queryKey: ['courses'],
+    queryFn: getCourses,
+  });
+
+  return (
+    <div className="fixed inset-0 z-0 overflow-hidden">
+      <div className="absolute inset-0 bg-[url('/forest-bg.png')] bg-center bg-cover bg-no-repeat">
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(180,200,190,0.3)_0%,rgba(200,210,200,0.2)_50%,rgba(180,195,185,0.4)_100%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,rgba(220,230,225,0.4)_0%,transparent_60%)]" />
+      </div>
+      <main className="relative z-10 min-h-screen p-6 pt-24 sm:p-8 sm:pt-28">
+        <div className="mx-auto max-w-4xl">
+          <h1 className="mb-6 text-2xl font-bold text-slate-900">Courses</h1>
+
+          {isLoading && (
+            <div className="flex min-h-[200px] items-center justify-center">
+              <p className="text-slate-600">Loading courses…</p>
+            </div>
+          )}
+
+          {isError && (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+              <p className="font-medium text-red-800">Failed to load courses</p>
+              <p className="mt-1 text-sm text-red-600">Check that the backend is running and try again.</p>
+            </div>
+          )}
+
+          {!isLoading && !isError && courses.length === 0 && (
+            <div className="flex min-h-[200px] flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white/50 p-12 text-center">
+              <p className="text-lg font-medium text-slate-700">No courses found</p>
+              <p className="mt-1 text-sm text-slate-500">Courses appear here once they are added to the graph.</p>
+            </div>
+          )}
+
+          {courses.length > 0 && (
+            <ul className="flex flex-col gap-3">
+              {courses.map((course) => (
+                <li
+                  key={course.code}
+                  className="glass-panel rounded-xl p-5 shadow-sm backdrop-blur-[30px]"
+                >
+                  <span className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                    {course.code}
+                  </span>
+                  <p className="mt-0.5 text-base font-medium text-slate-900">{course.name}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['health'],
     queryFn: async () => {
-      const response = await apiClient.get('/api/v1/health');
+      const response = await apiClient.get('/health');
       return response.data;
     },
   });

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -9,6 +9,7 @@ import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline'
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/backpack', label: 'Backpack' },
+  { href: '/courses', label: 'Courses' },
   { href: '/notes', label: 'Notes' },
   { href: '#', label: 'Chat' },
 ];

--- a/frontend/src/components/NotebookCard.tsx
+++ b/frontend/src/components/NotebookCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import type { NotebookResponse } from '../lib/api';
 import { TrashIcon } from '@heroicons/react/24/outline';
 
@@ -31,6 +32,7 @@ export default function NotebookCard({
   isEditing = false,
 }: NotebookCardProps) {
   return (
+    <Link href={`/backpack/${notebook.id}`}>
     <article className="glass-panel rounded-xl p-5 shadow-sm backdrop-blur-[30px] transition-shadow hover:shadow-md hover:cursor-pointer flex flex-col">
       <div className="flex flex-col items-start">
         <h3 className="text-lg font-semibold text-slate-900">
@@ -54,7 +56,7 @@ export default function NotebookCard({
         </p>
           <button
             type="button"
-            onClick={() => onDelete?.(notebook.id)}
+            onClick={(e) => { e.preventDefault(); onDelete?.(notebook.id); }}
             disabled={isDeleting}
             aria-label="Delete notebook"
             className="inline-flex items-center justify-center rounded-md p-2 text-slate-600 hover:cursor-pointer hover:text-slate-900 disabled:opacity-50"
@@ -65,6 +67,7 @@ export default function NotebookCard({
           </button>
         </div>
     </article>
+    </Link>
   );
 }
  

--- a/frontend/src/components/NotebookCard.tsx
+++ b/frontend/src/components/NotebookCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import type { NotebookResponse } from '../lib/api';
 import { TrashIcon } from '@heroicons/react/24/outline';
 
@@ -31,9 +31,13 @@ export default function NotebookCard({
   onEdit,
   isEditing = false,
 }: NotebookCardProps) {
+  const router = useRouter();
+
   return (
-    <Link href={`/backpack/${notebook.id}`}>
-    <article className="glass-panel rounded-xl p-5 shadow-sm backdrop-blur-[30px] transition-shadow hover:shadow-md hover:cursor-pointer flex flex-col">
+    <article
+      onClick={() => router.push(`/backpack/${notebook.id}`)}
+      className="glass-panel rounded-xl p-5 shadow-sm backdrop-blur-[30px] transition-shadow hover:shadow-md hover:cursor-pointer flex flex-col"
+    >
       <div className="flex flex-col items-start">
         <h3 className="text-lg font-semibold text-slate-900">
           {notebook.title}
@@ -49,25 +53,23 @@ export default function NotebookCard({
         </p>
       )}
 
-
       <div className="mt-auto flex justify-between items-center pt-4">
         <p className="text-xs text-green-700">
           Created on {formatDate(notebook.created_at)}
         </p>
-          <button
-            type="button"
-            onClick={(e) => { e.preventDefault(); onDelete?.(notebook.id); }}
-            disabled={isDeleting}
-            aria-label="Delete notebook"
-            className="inline-flex items-center justify-center rounded-md p-2 text-slate-600 hover:cursor-pointer hover:text-slate-900 disabled:opacity-50"
-          >
-            <TrashIcon
-              className={isDeleting ? 'size-5 animate-spin' : 'size-5'}
-            />
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onDelete?.(notebook.id); }}
+          disabled={isDeleting}
+          aria-label="Delete notebook"
+          className="inline-flex items-center justify-center rounded-md p-2 text-slate-600 hover:cursor-pointer hover:text-slate-900 disabled:opacity-50"
+        >
+          <TrashIcon
+            className={isDeleting ? 'size-5 animate-spin' : 'size-5'}
+          />
+        </button>
+      </div>
     </article>
-    </Link>
   );
 }
  

--- a/frontend/src/lib/api/courses.ts
+++ b/frontend/src/lib/api/courses.ts
@@ -12,7 +12,7 @@ export interface NotebookTagResponse {
 }
 
 export async function getCourses(): Promise<CourseResponse[]> {
-  const { data } = await apiClient.get<CourseResponse[]>('/api/v1/courses');
+  const { data } = await apiClient.get<CourseResponse[]>('/courses');
   return data;
 }
 
@@ -22,7 +22,7 @@ export async function addNotebookTag(
   courseCode: string
 ): Promise<NotebookTagResponse> {
   const { data } = await apiClient.post<NotebookTagResponse>(
-    `/api/v1/notebooks/${notebookId}/tags`,
+    `/notebooks/${notebookId}/tags`,
     { type, course_code: courseCode }
   );
   return data;
@@ -32,5 +32,5 @@ export async function removeNotebookTag(
   notebookId: string,
   courseCode: string
 ): Promise<void> {
-  await apiClient.delete(`/api/v1/notebooks/${notebookId}/tags/${courseCode}`);
+  await apiClient.delete(`/notebooks/${notebookId}/tags/${courseCode}`);
 }

--- a/frontend/src/lib/api/notebooks.ts
+++ b/frontend/src/lib/api/notebooks.ts
@@ -88,7 +88,8 @@ export async function uploadFile(
   if (sourceType) params.set('source_type', sourceType);
   const { data } = await apiClient.post<UploadFileResponse>(
     `/files/upload?${params.toString()}`,
-    form
+    form,
+    { headers: { 'Content-Type': undefined } }
   );
   return data;
 }

--- a/frontend/src/lib/api/notebooks.ts
+++ b/frontend/src/lib/api/notebooks.ts
@@ -22,7 +22,7 @@ export interface NotebookUpdate {
   description?: string | null;
 }
 
-const BASE = '/api/v1/notebooks';
+const BASE = '/notebooks';
 
 export async function getNotebooks(): Promise<NotebookResponse[]> {
   const { data } = await apiClient.get<NotebookResponse[]>(BASE);
@@ -87,7 +87,7 @@ export async function uploadFile(
   const params = new URLSearchParams({ notebook_id: notebookId });
   if (sourceType) params.set('source_type', sourceType);
   const { data } = await apiClient.post<UploadFileResponse>(
-    `/api/v1/files/upload?${params.toString()}`,
+    `/files/upload?${params.toString()}`,
     form
   );
   return data;


### PR DESCRIPTION
built out the core frontend pages and features: NotebookCard was made clickable to navigate to a new /backpack/[id] detail page, which supports inline metadata editing, file uploads (PDF/DOCX/PPTX with content/syllabus toggle), and course tag management. A /courses page was added to list all courses from the backend, and the create notebook form on /backpack gained an optional description field. Several bugs were also fixed during PR review — most notably a doubled /api/v1 path prefix causing 404s across all API calls, a missing multipart boundary on file uploads, and a few type/naming issues in the courses API.