### PR TITLE
Auth backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,9 @@ GOOGLE_APPLICATION_CREDENTIALS=./service-account-key.json
 
 # Optional for local dev (notebooks/health); required when Gemini embeddings or chat are integrated
 GEMINI_API_KEY=
+
+# Auth — required for all protected routes
+JWT_SECRET=
+
+# CORS — JSON array of allowed origins; defaults to localhost:3000 if omitted
+ALLOWED_ORIGINS=["http://localhost:3000"]

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,5 +14,5 @@ GEMINI_API_KEY=
 # Auth — required for all protected routes
 JWT_SECRET=
 
-# CORS — JSON array of allowed origins; defaults to localhost:3000 if omitted
-ALLOWED_ORIGINS=["http://localhost:3000"]
+# CORS — JSON array of allowed origins; defaults to http://localhost:3000 and http://127.0.0.1:3000 if omitted
+ALLOWED_ORIGINS=["http://localhost:3000", "http://127.0.0.1:3000"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -66,4 +66,4 @@ websockets==16.0
 neo4j
 neo4j-graphrag
 testcontainers[neo4j]
-PyJWT>=2.11.0
+PyJWT==2.11.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -66,3 +66,4 @@ websockets==16.0
 neo4j
 neo4j-graphrag
 testcontainers[neo4j]
+PyJWT>=2.11.0

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -21,7 +21,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_origins=settings.ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/src/api/routers/courses.py
+++ b/backend/src/api/routers/courses.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from neo4j import AsyncDriver
 from pydantic import BaseModel
 
+from src.lib.auth.jwt import get_current_user
 from src.lib.db.neo4j import get_driver
 from src.lib.repositories.course_repository import CourseRepository
 from src.lib.repositories.notebook_repository import NotebookRepository
@@ -41,6 +42,7 @@ async def add_notebook_tag(
     notebook_id: str,
     body: TagRequest,
     driver: AsyncDriver = Depends(get_driver),
+    current_user: str = Depends(get_current_user),
 ):
     """Write a PREREQUISITE_OF or RELATES_TO edge at the Course level.
 
@@ -51,6 +53,8 @@ async def add_notebook_tag(
     notebook = await NotebookRepository(driver).get_by_id(notebook_id)
     if notebook is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
+    if notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
 
     nb_course = notebook["course_code"]
     course_repo = CourseRepository(driver)
@@ -80,6 +84,7 @@ async def remove_notebook_tag(
     notebook_id: str,
     tag: str,
     driver: AsyncDriver = Depends(get_driver),
+    current_user: str = Depends(get_current_user),
 ):
     """Remove all PREREQUISITE_OF and RELATES_TO edges between the notebook's
     course and the course identified by {tag} (a course_code).
@@ -87,6 +92,8 @@ async def remove_notebook_tag(
     notebook = await NotebookRepository(driver).get_by_id(notebook_id)
     if notebook is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
+    if notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
 
     nb_course = notebook["course_code"]
 

--- a/backend/src/api/routers/files.py
+++ b/backend/src/api/routers/files.py
@@ -3,8 +3,10 @@ import uuid
 from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, UploadFile
 from neo4j import AsyncDriver
 
+from src.lib.auth.jwt import get_current_user
 from src.lib.db.neo4j import get_driver
 from src.lib.repositories.document_repository import DocumentRepository
+from src.lib.repositories.notebook_repository import NotebookRepository
 from src.lib.storage.gcs import storage_service
 from src.services.ingestion.ingestion_service import ingest_document
 
@@ -29,7 +31,14 @@ async def upload_document(
     file: UploadFile = File(...),
     driver: AsyncDriver = Depends(get_driver),
     source_type: str | None = Query(default=None),
+    current_user: str = Depends(get_current_user),
 ):
+    notebook = await NotebookRepository(driver).get_by_id(notebook_id)
+    if notebook is None:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    if notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
+
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file provided.")
 

--- a/backend/src/api/routers/notebooks.py
+++ b/backend/src/api/routers/notebooks.py
@@ -53,18 +53,25 @@ async def update_notebook_endpoint(
     notebook_id: str,
     data: NotebookUpdate,
     repo: NotebookRepository = Depends(get_repo),
+    current_user: str = Depends(get_current_user),
 ):
-    notebook = await repo.update(notebook_id, data)
-    if notebook is None:
+    existing = await repo.get_by_id(notebook_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
-    return notebook
+    if existing["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return await repo.update(notebook_id, data)
 
 
 @router.delete("/{notebook_id}", status_code=204)
 async def delete_notebook_endpoint(
     notebook_id: str,
     repo: NotebookRepository = Depends(get_repo),
+    current_user: str = Depends(get_current_user),
 ):
-    deleted = await repo.delete(notebook_id)
-    if not deleted:
+    existing = await repo.get_by_id(notebook_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
+    if existing["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    await repo.delete(notebook_id)

--- a/backend/src/api/routers/notebooks.py
+++ b/backend/src/api/routers/notebooks.py
@@ -60,7 +60,10 @@ async def update_notebook_endpoint(
         raise HTTPException(status_code=404, detail="Notebook not found")
     if existing["owner_id"] != current_user:
         raise HTTPException(status_code=403, detail="Not authorized")
-    return await repo.update(notebook_id, data)
+    updated = await repo.update(notebook_id, data)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    return updated
 
 
 @router.delete("/{notebook_id}", status_code=204)

--- a/backend/src/api/routers/notebooks.py
+++ b/backend/src/api/routers/notebooks.py
@@ -32,8 +32,9 @@ async def create_notebook_endpoint(
 @router.get("", response_model=list[NotebookRead], status_code=200)
 async def list_notebooks_endpoint(
     repo: NotebookRepository = Depends(get_repo),
+    current_user: str = Depends(get_current_user),
 ):
-    return await repo.list()
+    return await repo.list(owner_id=current_user)
 
 
 @router.get("/{notebook_id}", response_model=NotebookRead, status_code=200)

--- a/backend/src/api/routers/notebooks.py
+++ b/backend/src/api/routers/notebooks.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException
 from neo4j import AsyncDriver
 
+from src.lib.auth.jwt import get_current_user
 from src.lib.db.neo4j import get_driver
 from src.lib.repositories.notebook_repository import NotebookRepository
+from src.lib.repositories.user_repository import UserRepository
 from src.lib.schemas.notebook import NotebookCreate, NotebookRead, NotebookUpdate
 
 router = APIRouter()
@@ -12,12 +14,19 @@ def get_repo(driver: AsyncDriver = Depends(get_driver)) -> NotebookRepository:
     return NotebookRepository(driver)
 
 
+def get_user_repo(driver: AsyncDriver = Depends(get_driver)) -> UserRepository:
+    return UserRepository(driver)
+
+
 @router.post("", response_model=NotebookRead, status_code=201)
 async def create_notebook_endpoint(
     data: NotebookCreate,
     repo: NotebookRepository = Depends(get_repo),
+    user_repo: UserRepository = Depends(get_user_repo),
+    current_user: str = Depends(get_current_user),
 ):
-    return await repo.create(data)
+    await user_repo.create_or_get(current_user)
+    return await repo.create(data, owner_id=current_user)
 
 
 @router.get("", response_model=list[NotebookRead], status_code=200)

--- a/backend/src/api/routers/query.py
+++ b/backend/src/api/routers/query.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from neo4j import AsyncDriver
 from pydantic import BaseModel
 
+from src.lib.auth.jwt import get_current_user
 from src.lib.db.neo4j import get_driver
 from src.lib.repositories.notebook_repository import NotebookRepository
 from src.services.rag.graph_rag_service import GraphRAGService
@@ -28,10 +29,13 @@ async def query_notebook(
     body: QueryRequest,
     driver: AsyncDriver = Depends(get_driver),
     rag_service: GraphRAGService = Depends(get_rag_service),
+    current_user: str = Depends(get_current_user),
 ):
     notebook = await NotebookRepository(driver).get_by_id(notebook_id)
     if notebook is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
+    if notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
 
     result = await rag_service.query(notebook_id, body.query)
     return result

--- a/backend/src/lib/auth/jwt.py
+++ b/backend/src/lib/auth/jwt.py
@@ -1,0 +1,39 @@
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
+
+from ..config.settings import settings
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token")
+
+
+def decode_token(token: str) -> dict:
+    """Decode and validate a JWT. Raises HTTPException on failure."""
+    try:
+        return jwt.decode(token, settings.JWT_SECRET, algorithms=["HS256"])
+    except ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
+    """FastAPI dependency — returns the user ID (sub claim) from the token."""
+    payload = decode_token(token)
+    user_id: str | None = payload.get("sub")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing subject claim",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user_id

--- a/backend/src/lib/auth/jwt.py
+++ b/backend/src/lib/auth/jwt.py
@@ -5,7 +5,11 @@ from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 
 from ..config.settings import settings
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token")
+# Note: tokenUrl is a documented placeholder. Token issuance is handled by an
+# external authentication service and is not part of this FastAPI application.
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl="https://auth.example.com/oauth/token"
+)
 
 
 def decode_token(token: str) -> dict:

--- a/backend/src/lib/config/settings.py
+++ b/backend/src/lib/config/settings.py
@@ -25,6 +25,8 @@ class Settings(BaseSettings):
 
     JWT_SECRET: str = "dev-jwt-secret-change-in-production"
 
+    ALLOWED_ORIGINS: list[str] = ["http://localhost:3000", "http://127.0.0.1:3000"]
+
     # Optional until embedding / LLM paths are wired; omit or leave placeholder for local CRUD-only dev.
     gemini_api_key: str | None = Field(
         default=None,

--- a/backend/src/lib/config/settings.py
+++ b/backend/src/lib/config/settings.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
     GCS_BUCKET_NAME: str = "notebud-dev-bucket"
     GOOGLE_APPLICATION_CREDENTIALS: str = "./service-account-key.json"
 
+    JWT_SECRET: str = "dev-jwt-secret-change-in-production"
+
     # Optional until embedding / LLM paths are wired; omit or leave placeholder for local CRUD-only dev.
     gemini_api_key: str | None = Field(
         default=None,

--- a/backend/src/lib/config/settings.py
+++ b/backend/src/lib/config/settings.py
@@ -1,6 +1,10 @@
-from pydantic import AliasChoices, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
 import os
+
+from pydantic import AliasChoices, Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_JWT_DEV_PLACEHOLDER = "dev-jwt-secret-change-in-production"
+
 
 class Settings(BaseSettings):
     ENVIRONMENT: str = "development"
@@ -23,7 +27,7 @@ class Settings(BaseSettings):
     GCS_BUCKET_NAME: str = "notebud-dev-bucket"
     GOOGLE_APPLICATION_CREDENTIALS: str = "./service-account-key.json"
 
-    JWT_SECRET: str = "dev-jwt-secret-change-in-production"
+    JWT_SECRET: str = _JWT_DEV_PLACEHOLDER
 
     ALLOWED_ORIGINS: list[str] = ["http://localhost:3000", "http://127.0.0.1:3000"]
 
@@ -37,5 +41,13 @@ class Settings(BaseSettings):
         env_file=(".env", f".env.{os.getenv('ENVIRONMENT', 'development')}"),
         env_file_encoding="utf-8",
     )
+
+    @model_validator(mode="after")
+    def _require_strong_jwt_secret_in_prod(self) -> "Settings":
+        if self.ENVIRONMENT != "development" and self.JWT_SECRET == _JWT_DEV_PLACEHOLDER:
+            raise ValueError(
+                "JWT_SECRET must be set to a strong secret in non-development environments."
+            )
+        return self
 
 settings = Settings()

--- a/backend/src/lib/repositories/notebook_repository.py
+++ b/backend/src/lib/repositories/notebook_repository.py
@@ -21,7 +21,7 @@ class NotebookRepository:
     def __init__(self, driver: AsyncDriver):
         self._driver = driver
 
-    async def create(self, data: NotebookCreate) -> dict:
+    async def create(self, data: NotebookCreate, owner_id: str | None = None) -> dict:
         notebook_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
         query = """
@@ -49,7 +49,7 @@ class NotebookRepository:
                 course_code=data.course_code,
                 description=data.description,
                 now=now,
-                owner_id=None,
+                owner_id=owner_id,
             )
             record = await result.single()
             return _node_to_dict(record["n"])

--- a/backend/src/lib/repositories/notebook_repository.py
+++ b/backend/src/lib/repositories/notebook_repository.py
@@ -63,10 +63,10 @@ class NotebookRepository:
                 return None
             return _node_to_dict(record["n"])
 
-    async def list(self) -> list[dict]:
-        query = "MATCH (n:Notebook) RETURN n ORDER BY n.created_at DESC"
+    async def list(self, owner_id: str) -> list[dict]:
+        query = "MATCH (n:Notebook {owner_id: $owner_id}) RETURN n ORDER BY n.created_at DESC"
         async with self._driver.session() as session:
-            result = await session.run(query)
+            result = await session.run(query, owner_id=owner_id)
             return [_node_to_dict(record["n"]) async for record in result]
 
     async def update(self, notebook_id: str, data: NotebookUpdate) -> dict | None:

--- a/backend/src/lib/repositories/user_repository.py
+++ b/backend/src/lib/repositories/user_repository.py
@@ -14,4 +14,11 @@ class UserRepository:
         async with self._driver.session() as session:
             result = await session.run(query, user_id=user_id)
             record = await result.single()
-            return dict(record["u"])
+            if record is None:
+                # Fallback to a minimal representation if no record is returned
+                return {"id": user_id}
+            user_node = record.get("u")
+            if user_node is None:
+                # Fallback to a minimal representation if the expected key is missing
+                return {"id": user_id}
+            return dict(user_node)

--- a/backend/src/lib/repositories/user_repository.py
+++ b/backend/src/lib/repositories/user_repository.py
@@ -1,0 +1,17 @@
+from neo4j import AsyncDriver
+
+
+class UserRepository:
+    def __init__(self, driver: AsyncDriver):
+        self._driver = driver
+
+    async def create_or_get(self, user_id: str) -> dict:
+        """Upsert a :User node by ID and return its properties."""
+        query = """
+            MERGE (u:User {id: $user_id})
+            RETURN u
+        """
+        async with self._driver.session() as session:
+            result = await session.run(query, user_id=user_id)
+            record = await result.single()
+            return dict(record["u"])

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -869,21 +869,21 @@ allow_origins=settings.ALLOWED_ORIGINS  # new settings field
 
 ### Group B — Frontend: API Layer Completion
 
-- [ ] S5-09: Add `uploadFile(notebookId, file, sourceType?)` to `notebooks.ts` *(needs S5-03)*
-- [ ] S5-10: Add `queryNotebook(id, query)` to `notebooks.ts` *(needs S5-03)*
-- [ ] S5-11: Create `frontend/src/lib/api/courses.ts` with `getCourses`, `addNotebookTag`, `removeNotebookTag`
-- [ ] S5-12: Re-export new functions (`uploadFile`, `queryNotebook`, courses API) from `lib/api/index.ts` *(needs S5-09 – S5-11)*
+- [x] S5-09: Add `uploadFile(notebookId, file, sourceType?)` to `notebooks.ts` *(needs S5-03)*
+- [x] S5-10: Add `queryNotebook(id, query)` to `notebooks.ts` *(needs S5-03)*
+- [x] S5-11: Create `frontend/src/lib/api/courses.ts` with `getCourses`, `addNotebookTag`, `removeNotebookTag`
+- [x] S5-12: Re-export new functions (`uploadFile`, `queryNotebook`, courses API) from `lib/api/index.ts` *(needs S5-09 – S5-11)*
 
 ---
 
 ### Group C — Frontend: Page & Feature Build-out
 
-- [ ] S5-13: Make `NotebookCard` clickable — navigate to `/backpack/[id]` on card click *(needs S5-04)*
-- [ ] S5-14: Build `/backpack/[id]` notebook detail page: display metadata, inline edit via `updateNotebook` *(needs S5-05, S5-13)*
-- [ ] S5-15: Add file upload section to `/backpack/[id]`: PDF/DOCX/PPTX input, source type toggle, call `uploadFile` *(needs S5-09, S5-14)*
-- [ ] S5-16: Add course tag section to `/backpack/[id]`: course autocomplete from `getCourses`, add/remove tags *(needs S5-11, S5-14)*
-- [ ] S5-17: Build `/courses` page: list all courses with relationship display *(needs S5-11)*
-- [ ] S5-18: Add description field to the create notebook form on `/backpack` *(needs S5-08)*
+- [x] S5-13: Make `NotebookCard` clickable — navigate to `/backpack/[id]` on card click *(needs S5-04)*
+- [x] S5-14: Build `/backpack/[id]` notebook detail page: display metadata, inline edit via `updateNotebook` *(needs S5-05, S5-13)*
+- [x] S5-15: Add file upload section to `/backpack/[id]`: PDF/DOCX/PPTX input, source type toggle, call `uploadFile` *(needs S5-09, S5-14)*
+- [x] S5-16: Add course tag section to `/backpack/[id]`: course autocomplete from `getCourses`, add/remove tags *(needs S5-11, S5-14)*
+- [x] S5-17: Build `/courses` page: list all courses with relationship display *(needs S5-11)*
+- [x] S5-18: Add description field to the create notebook form on `/backpack` *(needs S5-08)*
 
 ---
 
@@ -915,11 +915,11 @@ allow_origins=settings.ALLOWED_ORIGINS  # new settings field
 
 ### Group G — Auth: Backend
 
-- [ ] S5-30: Add `JWT_SECRET` to `backend/.env.development`
-- [ ] S5-31: Create `backend/src/lib/auth/jwt.py`: `decode_token()` and `get_current_user()` FastAPI dependency *(needs S5-30)*
-- [ ] S5-32: Create `UserRepository`: `create_or_get(user_id)` that upserts a `:User` node *(needs S5-31)*
-- [ ] S5-33: Inject auth into `POST /notebooks`: set `owner_id = current_user` *(needs S5-31)*
-- [ ] S5-34: Scope `GET /notebooks` to authenticated user: filter `WHERE n.owner_id = $user_id` *(needs S5-33)*
+- [x] S5-30: Add `JWT_SECRET` to `backend/.env.development`
+- [x] S5-31: Create `backend/src/lib/auth/jwt.py`: `decode_token()` and `get_current_user()` FastAPI dependency *(needs S5-30)*
+- [x] S5-32: Create `UserRepository`: `create_or_get(user_id)` that upserts a `:User` node *(needs S5-31)*
+- [x] S5-33: Inject auth into `POST /notebooks`: set `owner_id = current_user` *(needs S5-31)*
+- [x] S5-34: Scope `GET /notebooks` to authenticated user: filter `WHERE n.owner_id = $user_id` *(needs S5-33)*
 - [ ] S5-35: Guard `PATCH`, `DELETE /notebooks/{id}`, `POST /files/upload`, `POST /notebooks/{id}/tags`, `POST /notebooks/{id}/query` — 403 if ownership mismatch *(needs S5-33)*
 - [ ] S5-36: Add `ALLOWED_ORIGINS` setting to `backend/src/lib/config/settings.py` and update CORS in `main.py`
 - [ ] S5-37: Add `ALLOWED_ORIGINS` to `backend/.env.development` and `.env.staging` *(needs S5-36)*

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -920,9 +920,9 @@ allow_origins=settings.ALLOWED_ORIGINS  # new settings field
 - [x] S5-32: Create `UserRepository`: `create_or_get(user_id)` that upserts a `:User` node *(needs S5-31)*
 - [x] S5-33: Inject auth into `POST /notebooks`: set `owner_id = current_user` *(needs S5-31)*
 - [x] S5-34: Scope `GET /notebooks` to authenticated user: filter `WHERE n.owner_id = $user_id` *(needs S5-33)*
-- [ ] S5-35: Guard `PATCH`, `DELETE /notebooks/{id}`, `POST /files/upload`, `POST /notebooks/{id}/tags`, `POST /notebooks/{id}/query` — 403 if ownership mismatch *(needs S5-33)*
-- [ ] S5-36: Add `ALLOWED_ORIGINS` setting to `backend/src/lib/config/settings.py` and update CORS in `main.py`
-- [ ] S5-37: Add `ALLOWED_ORIGINS` to `backend/.env.development` and `.env.staging` *(needs S5-36)*
+- [x] S5-35: Guard `PATCH`, `DELETE /notebooks/{id}`, `POST /files/upload`, `POST /notebooks/{id}/tags`, `POST /notebooks/{id}/query` — 403 if ownership mismatch *(needs S5-33)*
+- [x] S5-36: Add `ALLOWED_ORIGINS` setting to `backend/src/lib/config/settings.py` and update CORS in `main.py`
+- [x] S5-37: Add `ALLOWED_ORIGINS` to `backend/.env.development` and `.env.staging` *(needs S5-36)*
 
 ---
 


### PR DESCRIPTION
Implements backend authentication infrastructure using JWT (HS256 via PyJWT). Adds decode_token and get_current_user FastAPI dependency in src/lib/auth/jwt.py, backed by a JWT_SECRET setting. Introduces UserRepository.create_or_get to upsert a :User node on first login. All write routes — POST, PATCH, DELETE /notebooks, POST /files/upload, POST /notebooks/{id}/tags, and POST /notebooks/{id}/query — now require a valid token, with GET /notebooks scoped to the authenticated user's own notebooks and all mutating routes returning 403 on ownership mismatch. CORS origins are extracted from a new ALLOWED_ORIGINS setting so staging/prod origins can be injected without code changes.