### PR TITLE
Fix authorization headers clearing on signout and protect routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ npm run dev
 For in-memory notebook data during UI or hook tests, pass `{ mock: true }` into the hooks in `frontend/src/hooks/useNotebooks.ts` (the Backpack page uses the live API by default). See [frontend/README.md](frontend/README.md#backpack-and-mock-data).
 
 Notes are now notebook-scoped under `frontend/src/app/backpack/[id]/notes/page.tsx` and are opened from notebook cards. See [frontend/README.md](frontend/README.md#notes-workspace-routing-and-ui) for UI details (`FileTree`, tabs, and modal behavior).
+Architecture overview: [docs/notes-workspace-ui-architecture.md](docs/notes-workspace-ui-architecture.md).
 
 **Backend .env:** Copy `backend/.env.example` to `.env`. Set `NEO4J_URI`, `NEO4J_USERNAME`, and `NEO4J_PASSWORD` to match `backend/infrastructure/docker/docker-compose.yml` (default compose auth is `neo4j` / `notebud_password`). `GEMINI_API_KEY` is optional until embedding/LLM paths are enabled. Graph constraints and indexes are applied at API startup—there is no Alembic or SQL migration step. The API is at `http://localhost:8000`; health check: `http://localhost:8000/api/v1/health`.
 

--- a/docs/notes-workspace-ui-architecture.md
+++ b/docs/notes-workspace-ui-architecture.md
@@ -1,0 +1,47 @@
+# Notes Workspace UI Architecture
+
+This document describes how the notebook-scoped notes workspace is assembled in the frontend.
+
+## Entry points
+
+- Backpack detail: `frontend/src/app/backpack/[id]/page.tsx`
+- Notes workspace: `frontend/src/app/backpack/[id]/notes/page.tsx`
+- Notebook card navigation: `frontend/src/components/NotebookCard.tsx`
+
+Notebook cards navigate to the notes workspace using a notebook-scoped route:
+
+- `/backpack/:id/notes`
+
+## Component map
+
+```mermaid
+flowchart TD
+  A[NotebookCard] -->|Link /backpack/:id/notes| B[Notes Page]
+  B --> C[NotesTabs]
+  B --> D[FileTree Left Pane]
+  B --> E[Note Content Center Pane]
+  B --> F[Chat Right Pane]
+  C -->|Add tab| G[NotebookUploadAndCourseTagsModal]
+  G --> H[NotebookUploadAndCourseTags]
+```
+
+## Behavior notes
+
+- `NotesTabs` controls:
+  - open/close left file-tree pane
+  - open/close right chat pane
+  - tab selection and tab close behavior
+  - add-tab action that opens the upload/course-tags modal
+- `FileTree` supports:
+  - nested folders and files
+  - per-folder expand/collapse
+  - optional `onSelectFile` callback for wiring selection into note content
+- `NotebookUploadAndCourseTagsModal`:
+  - renders centered in viewport
+  - expects notebook context from the notebook-scoped notes route
+
+## Route conventions
+
+- Primary notes workflow: `/backpack/:id/notes`
+- Top-level `/notes` is not the primary workspace entry and should not be the default navigation target.
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -65,6 +65,7 @@ The hooks in `src/hooks/useNotebooks.ts` also support **`{ mock: true }`**, whic
 - **Legacy `/notes` route:** This route has been removed and is no longer available; notes should be opened from a notebook context via `/backpack/:id/notes`.
 - **Left pane file tree:** `src/components/FileTree.tsx` renders nested folders/files with expand/collapse support.
 - **Upload modal:** `src/modals/NotebookUploadAndCourseTagsModal.tsx` is viewport-centered and expects notebook context from backpack-scoped notes.
+- **Architecture doc:** [../docs/notes-workspace-ui-architecture.md](../docs/notes-workspace-ui-architecture.md)
 
 ### `FileTree` quick usage
 

--- a/frontend/src/app/backpack/layout.tsx
+++ b/frontend/src/app/backpack/layout.tsx
@@ -1,0 +1,7 @@
+import { type ReactNode } from 'react';
+import RequireAuth from '../../components/auth/RequireAuth';
+
+export default function BackpackLayout({ children }: { children: ReactNode }) {
+  return <RequireAuth>{children}</RequireAuth>;
+}
+

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -20,8 +20,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NavBar />
-        <Providers>{children}</Providers>
+        <Providers>
+          <NavBar />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { Disclosure, DisclosureButton, DisclosurePanel, Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid'
 import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline'
@@ -10,13 +10,12 @@ import { useAuthStore } from '../lib/store/auth'
 import { abortAllInFlightRequests, disableAuthHeadersFor } from '../lib/api/client'
 
 const navLinks = [
-  { href: '/', label: 'Home' },
-  { href: '/backpack', label: 'Backpack' },
+  { href: '/', label: 'Home', protected: false },
+  { href: '/backpack', label: 'Backpack', protected: true },
 ];
 
 export default function NavBar() {
   const pathname = usePathname();
-  const router = useRouter();
   const token = useAuthStore((s) => s.token);
   const username = useAuthStore((s) => s.username);
   const clearSession = useAuthStore((s) => s.clearSession);
@@ -49,17 +48,14 @@ export default function NavBar() {
               />
             </div>
             <div className="hidden lg:ml-6 lg:flex lg:space-x-8">
-              {navLinks.map(({ href, label }) => {
+              {navLinks.map(({ href, label, protected: isProtected }) => {
                 const linkPath = href.split('?')[0]
                 const isActive = href !== '#' && pathname === linkPath
                 const activeClass = 'border-emerald-600 text-gray-900'
                 const defaultClass = 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                return token ? (
-                  <Link key={label} href={href} className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${isActive ? activeClass : defaultClass}`}>
-                    {label}
-                  </Link>
-                ) : (
-                  <Link key={label} href="/login" className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${isActive ? activeClass : defaultClass}`}>
+                const resolvedHref = isProtected && !token ? '/login' : href
+                return (
+                  <Link key={label} href={resolvedHref} className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${isActive ? activeClass : defaultClass}`}>
                     {label}
                   </Link>
                 )
@@ -150,18 +146,15 @@ export default function NavBar() {
 
       <DisclosurePanel className="lg:hidden">
         <div className="space-y-1 pt-2 pb-3">
-          {navLinks.map(({ href, label }) => {
+          {navLinks.map(({ href, label, protected: isProtected }) => {
             const linkPath = href.split('?')[0]
             const isActive = href !== '#' && pathname === linkPath
             const activeClass = 'border-emerald-600 bg-emerald-50 text-emerald-700'
             const defaultClass = 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
             const baseClass = `block border-l-4 py-2 pr-4 pl-3 text-base font-medium ${isActive ? activeClass : defaultClass}`
-            return href === '#' ? (
-              <DisclosureButton key={label} as="a" href="#" className={baseClass}>
-                {label}
-              </DisclosureButton>
-            ) : (
-              <DisclosureButton key={label} as={Link} href={href} className={baseClass}>
+            const resolvedHref = isProtected && !token ? '/login' : href
+            return (
+              <DisclosureButton key={label} as={Link} href={resolvedHref} className={baseClass}>
                 {label}
               </DisclosureButton>
             )

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -5,7 +5,9 @@ import { usePathname, useRouter } from 'next/navigation'
 import { Disclosure, DisclosureButton, DisclosurePanel, Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid'
 import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '../lib/store/auth'
+import { abortAllInFlightRequests, disableAuthHeadersFor } from '../lib/api/client'
 
 const navLinks = [
   { href: '/', label: 'Home' },
@@ -18,10 +20,18 @@ export default function NavBar() {
   const token = useAuthStore((s) => s.token);
   const username = useAuthStore((s) => s.username);
   const clearSession = useAuthStore((s) => s.clearSession);
+  const queryClient = useQueryClient();
 
   const handleLogout = () => {
+    // Prevent any already-started/soon-to-refetch queries from continuing
+    // after the user logs out.
+    queryClient.cancelQueries();
+    queryClient.clear();
+    abortAllInFlightRequests();
     clearSession();
-    router.push('/login');
+    disableAuthHeadersFor(10000);
+    // Force a full reload so React Query cache + any bfcache restore can't show stale protected UI.
+    window.location.assign('/login');
   };
 
   const displayInitial = username?.trim()?.charAt(0).toUpperCase() || '?';
@@ -42,23 +52,14 @@ export default function NavBar() {
               {navLinks.map(({ href, label }) => {
                 const linkPath = href.split('?')[0]
                 const isActive = href !== '#' && pathname === linkPath
-                const baseClass = 'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium'
                 const activeClass = 'border-emerald-600 text-gray-900'
                 const defaultClass = 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                return href === '#' ? (
-                  <a
-                    key={label}
-                    href="#"
-                    className={`${baseClass} ${defaultClass}`}
-                  >
+                return token ? (
+                  <Link key={label} href={href} className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${isActive ? activeClass : defaultClass}`}>
                     {label}
-                  </a>
+                  </Link>
                 ) : (
-                  <Link
-                    key={label}
-                    href={href}
-                    className={`${baseClass} ${isActive ? activeClass : defaultClass}`}
-                  >
+                  <Link key={label} href="/login" className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${isActive ? activeClass : defaultClass}`}>
                     {label}
                   </Link>
                 )

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { useAuthStore } from '../../lib/store/auth';
+import { abortAllInFlightRequests, disableAuthHeadersFor } from '../../lib/api/client';
+
+export default function RequireAuth({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const token = useAuthStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const [hydrated, setHydrated] = useState(() =>
+    useAuthStore.persist.hasHydrated()
+  );
+
+  useEffect(() => {
+    if (useAuthStore.persist.hasHydrated()) {
+      setHydrated(true);
+      return;
+    }
+    return useAuthStore.persist.onFinishHydration(() => {
+      setHydrated(true);
+    });
+  }, []);
+
+  const redirectToLogin = () => {
+    // Avoid showing cached React Query data after logout/back navigation.
+    queryClient.cancelQueries();
+    queryClient.clear();
+    const from = pathname || '/backpack';
+    abortAllInFlightRequests();
+    // Prevent any new requests triggered by the still-mounted tree
+    // from reattaching stale Authorization during the redirect window.
+    disableAuthHeadersFor(10000);
+    // Use a full navigation so bfcache/history can't temporarily display protected UI.
+    window.location.assign(`/login?from=${encodeURIComponent(from)}`);
+  };
+
+  useLayoutEffect(() => {
+    if (!hydrated) return;
+    if (!token) redirectToLogin();
+  }, [hydrated, token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    // bfcache/back-forward can revive a page with stale UI; re-check on pageshow.
+    const onPageShow = (e: PageTransitionEvent) => {
+      if (!e.persisted) return;
+      if (!hydrated) return;
+      const currentToken = useAuthStore.getState().token;
+      if (!currentToken) redirectToLogin();
+    };
+
+    window.addEventListener('pageshow', onPageShow);
+    return () => window.removeEventListener('pageshow', onPageShow);
+  }, [hydrated, token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Block showing protected UI while we know the user is logged out.
+  if (!hydrated) return null;
+  if (!token) return null;
+
+  return <>{children}</>;
+}
+

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -69,7 +69,6 @@ apiClient.interceptors.request.use((config) => {
     const headers = (config.headers ?? {}) as any;
     config.headers = headers;
     delete headers.Authorization;
-    headers['X-Auth-Source'] = 'disabled-window';
     return config;
   }
 
@@ -84,33 +83,20 @@ apiClient.interceptors.request.use((config) => {
 
   // Default: never send Authorization unless BOTH store+persist agree.
   delete headers.Authorization;
-  delete headers['X-Auth-Source'];
 
   // If localStorage key is gone, do not send auth even if storeToken is stale.
   if (raw === null) {
-    headers['X-Auth-Source'] = 'no-persisted-key';
     return config;
   }
 
   const persistedToken = getPersistedAuthToken();
   // After signout we expect the store token to be null immediately. If it isn't,
   // requiring both sources prevents stale auth headers from being sent.
-  if (!persistedToken) {
-    headers['X-Auth-Source'] = 'persisted-token-missing';
-    return config;
-  }
-  if (!storeToken) {
-    headers['X-Auth-Source'] = 'store-token-missing';
-    return config;
-  }
-
-  if (persistedToken !== storeToken) {
-    headers['X-Auth-Source'] = 'token-mismatch';
+  if (!persistedToken || !storeToken || persistedToken !== storeToken) {
     return config;
   }
 
   headers.Authorization = `Bearer ${persistedToken}`;
-  headers['X-Auth-Source'] = 'persisted+store';
   return config;
 });
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosError } from 'axios';
 import { useAuthStore } from '../store/auth';
 
 const baseURL = process.env.NEXT_PUBLIC_API_URL;
+const AUTH_STORE_KEY = 'notebud-auth';
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
   const u = baseURL ?? '';
@@ -21,16 +22,95 @@ export const apiClient = axios.create({
   withCredentials: true,
 });
 
+let authDisabledUntil = 0;
+const inFlightControllers = new Set<AbortController>();
+const controllerKey = Symbol('authAbortController');
+
+/**
+ * Prevent Axios from attaching Authorization for a short window.
+ * Helps avoid stale Authorization headers being attached to requests
+ * triggered during/after sign-out before all client state settles.
+ */
+export function disableAuthHeadersFor(ms: number = 5000) {
+  authDisabledUntil = Date.now() + ms;
+}
+
+/** Abort all currently in-flight API requests (used on logout). */
+export function abortAllInFlightRequests() {
+  for (const c of inFlightControllers) c.abort();
+  inFlightControllers.clear();
+}
+
 function getAuthToken(): string | null {
   if (typeof window === 'undefined') return null;
   return useAuthStore.getState().token;
 }
 
-apiClient.interceptors.request.use((config) => {
-  const token = getAuthToken();
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+function getPersistedAuthToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  const raw = window.localStorage.getItem(AUTH_STORE_KEY);
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as { state?: { token?: string | null } };
+    return parsed?.state?.token ?? null;
+  } catch {
+    return null;
   }
+}
+
+apiClient.interceptors.request.use((config) => {
+  // Ensure every request is abortable so we can stop in-flight calls on logout.
+  const controller = new AbortController();
+  inFlightControllers.add(controller);
+  (config as any)[controllerKey] = controller;
+  config.signal = controller.signal;
+
+  if (Date.now() < authDisabledUntil) {
+    const headers = (config.headers ?? {}) as any;
+    config.headers = headers;
+    delete headers.Authorization;
+    headers['X-Auth-Source'] = 'disabled-window';
+    return config;
+  }
+
+  const storeToken = getAuthToken();
+  const raw =
+    typeof window !== 'undefined'
+      ? window.localStorage.getItem(AUTH_STORE_KEY)
+      : null;
+
+  const headers = (config.headers ?? {}) as any;
+  config.headers = headers;
+
+  // Default: never send Authorization unless BOTH store+persist agree.
+  delete headers.Authorization;
+  delete headers['X-Auth-Source'];
+
+  // If localStorage key is gone, do not send auth even if storeToken is stale.
+  if (raw === null) {
+    headers['X-Auth-Source'] = 'no-persisted-key';
+    return config;
+  }
+
+  const persistedToken = getPersistedAuthToken();
+  // After signout we expect the store token to be null immediately. If it isn't,
+  // requiring both sources prevents stale auth headers from being sent.
+  if (!persistedToken) {
+    headers['X-Auth-Source'] = 'persisted-token-missing';
+    return config;
+  }
+  if (!storeToken) {
+    headers['X-Auth-Source'] = 'store-token-missing';
+    return config;
+  }
+
+  if (persistedToken !== storeToken) {
+    headers['X-Auth-Source'] = 'token-mismatch';
+    return config;
+  }
+
+  headers.Authorization = `Bearer ${persistedToken}`;
+  headers['X-Auth-Source'] = 'persisted+store';
   return config;
 });
 
@@ -40,8 +120,14 @@ function isAuthRequest(url: string | undefined): boolean {
 }
 
 apiClient.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    const controller = (response.config as any)?.[controllerKey] as AbortController | undefined;
+    if (controller) inFlightControllers.delete(controller);
+    return response;
+  },
   (error: AxiosError) => {
+    const controller = (error.config as any)?.[controllerKey] as AbortController | undefined;
+    if (controller) inFlightControllers.delete(controller);
     if (error.response?.status === 401) {
       const reqUrl = error.config?.url ?? '';
       if (!isAuthRequest(reqUrl)) {

--- a/frontend/src/lib/store/auth.ts
+++ b/frontend/src/lib/store/auth.ts
@@ -16,7 +16,13 @@ export const useAuthStore = create<AuthState>()(
       userId: null,
       username: null,
       setSession: (token, userId, username) => set({ token, userId, username }),
-      clearSession: () => set({ token: null, userId: null, username: null }),
+      clearSession: () => {
+        set({ token: null, userId: null, username: null });
+        // Ensure the persisted session does not get re-hydrated from localStorage.
+        if (typeof window !== 'undefined') {
+          window.localStorage.removeItem('notebud-auth');
+        }
+      },
     }),
     { name: 'notebud-auth' }
   )


### PR DESCRIPTION
- [x] Remove `X-Auth-Source` debug header from `client.ts` (no longer leaks internal auth state or causes CORS preflights)
- [x] Remove unused `useRouter` import and `router` variable from `NavBar.tsx`
- [x] Fix desktop nav link logic to only redirect protected routes (`/backpack`) to `/login`; public routes like `/` (Home) remain accessible without auth
- [x] Apply the same consistent auth-guard logic to the mobile menu, eliminating desktop/mobile divergence