### PR TITLE
Feature/notebook note storage

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from src.lib.config.settings import settings
 from src.lib.db.neo4j import startup, close_driver
-from src.api.routers import health, files, notebooks, query, courses, auth
+from src.api.routers import health, files, notebooks, notes, query, courses, auth
 
 
 @asynccontextmanager
@@ -49,6 +49,12 @@ app.include_router(
     notebooks.router,
     prefix=f"{settings.API_V1_STR}/notebooks",
     tags=["Notebooks"],
+)
+
+app.include_router(
+    notes.router,
+    prefix=f"{settings.API_V1_STR}/notebooks",
+    tags=["Notes"],
 )
 
 app.include_router(

--- a/backend/src/api/routers/notes.py
+++ b/backend/src/api/routers/notes.py
@@ -1,11 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from neo4j import AsyncDriver
 
 from src.lib.auth.jwt import get_current_user
 from src.lib.db.neo4j import get_driver
+from src.lib.repositories.note_chunk_repository import NoteChunkRepository
 from src.lib.repositories.note_repository import NoteRepository
 from src.lib.repositories.notebook_repository import NotebookRepository
 from src.lib.schemas.note import NoteCreate, NoteRead, NoteUpdate
+from src.services.ingestion.note_ingestion_service import ingest_note
 
 router = APIRouter()
 
@@ -18,18 +20,30 @@ def get_notebook_repo(driver: AsyncDriver = Depends(get_driver)) -> NotebookRepo
     return NotebookRepository(driver)
 
 
+def get_note_chunk_repo(driver: AsyncDriver = Depends(get_driver)) -> NoteChunkRepository:
+    return NoteChunkRepository(driver)
+
+
 @router.post("/{notebook_id}/notes", response_model=NoteRead, status_code=201)
 async def create_note_endpoint(
     notebook_id: str,
     data: NoteCreate,
+    background_tasks: BackgroundTasks,
     repo: NoteRepository = Depends(get_repo),
     notebook_repo: NotebookRepository = Depends(get_notebook_repo),
+    driver: AsyncDriver = Depends(get_driver),
     current_user: str = Depends(get_current_user),
 ):
     notebook = await notebook_repo.get_by_id(notebook_id)
     if notebook is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
-    return await repo.create(notebook_id, data, owner_id=current_user)
+    note = await repo.create(notebook_id, data, owner_id=current_user)
+    if note["content"]:
+        background_tasks.add_task(
+            ingest_note,
+            driver, note["id"], note["title"], note["content"], notebook_id,
+        )
+    return note
 
 
 @router.get("/{notebook_id}/notes", response_model=list[NoteRead], status_code=200)
@@ -63,7 +77,9 @@ async def update_note_endpoint(
     notebook_id: str,
     note_id: str,
     data: NoteUpdate,
+    background_tasks: BackgroundTasks,
     repo: NoteRepository = Depends(get_repo),
+    driver: AsyncDriver = Depends(get_driver),
     current_user: str = Depends(get_current_user),
 ):
     existing = await repo.get_by_id(note_id)
@@ -74,6 +90,11 @@ async def update_note_endpoint(
     updated = await repo.update(note_id, data)
     if updated is None:
         raise HTTPException(status_code=404, detail="Note not found")
+    if "content" in data.model_dump(exclude_unset=True):
+        background_tasks.add_task(
+            ingest_note,
+            driver, note_id, updated["title"], updated["content"], notebook_id,
+        )
     return updated
 
 
@@ -82,6 +103,7 @@ async def delete_note_endpoint(
     notebook_id: str,
     note_id: str,
     repo: NoteRepository = Depends(get_repo),
+    note_chunk_repo: NoteChunkRepository = Depends(get_note_chunk_repo),
     current_user: str = Depends(get_current_user),
 ):
     existing = await repo.get_by_id(note_id)
@@ -89,4 +111,5 @@ async def delete_note_endpoint(
         raise HTTPException(status_code=404, detail="Note not found")
     if existing["owner_id"] != current_user:
         raise HTTPException(status_code=403, detail="Not authorized")
+    await note_chunk_repo.delete_by_note(note_id)
     await repo.delete(note_id)

--- a/backend/src/api/routers/notes.py
+++ b/backend/src/api/routers/notes.py
@@ -1,0 +1,92 @@
+from fastapi import APIRouter, Depends, HTTPException
+from neo4j import AsyncDriver
+
+from src.lib.auth.jwt import get_current_user
+from src.lib.db.neo4j import get_driver
+from src.lib.repositories.note_repository import NoteRepository
+from src.lib.repositories.notebook_repository import NotebookRepository
+from src.lib.schemas.note import NoteCreate, NoteRead, NoteUpdate
+
+router = APIRouter()
+
+
+def get_repo(driver: AsyncDriver = Depends(get_driver)) -> NoteRepository:
+    return NoteRepository(driver)
+
+
+def get_notebook_repo(driver: AsyncDriver = Depends(get_driver)) -> NotebookRepository:
+    return NotebookRepository(driver)
+
+
+@router.post("/{notebook_id}/notes", response_model=NoteRead, status_code=201)
+async def create_note_endpoint(
+    notebook_id: str,
+    data: NoteCreate,
+    repo: NoteRepository = Depends(get_repo),
+    notebook_repo: NotebookRepository = Depends(get_notebook_repo),
+    current_user: str = Depends(get_current_user),
+):
+    notebook = await notebook_repo.get_by_id(notebook_id)
+    if notebook is None:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    return await repo.create(notebook_id, data, owner_id=current_user)
+
+
+@router.get("/{notebook_id}/notes", response_model=list[NoteRead], status_code=200)
+async def list_notes_endpoint(
+    notebook_id: str,
+    repo: NoteRepository = Depends(get_repo),
+    notebook_repo: NotebookRepository = Depends(get_notebook_repo),
+    current_user: str = Depends(get_current_user),
+):
+    notebook = await notebook_repo.get_by_id(notebook_id)
+    if notebook is None:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    return await repo.list(notebook_id)
+
+
+@router.get("/{notebook_id}/notes/{note_id}", response_model=NoteRead, status_code=200)
+async def get_note_endpoint(
+    notebook_id: str,
+    note_id: str,
+    repo: NoteRepository = Depends(get_repo),
+    current_user: str = Depends(get_current_user),
+):
+    note = await repo.get_by_id(note_id)
+    if note is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    return note
+
+
+@router.patch("/{notebook_id}/notes/{note_id}", response_model=NoteRead, status_code=200)
+async def update_note_endpoint(
+    notebook_id: str,
+    note_id: str,
+    data: NoteUpdate,
+    repo: NoteRepository = Depends(get_repo),
+    current_user: str = Depends(get_current_user),
+):
+    existing = await repo.get_by_id(note_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    if existing["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    updated = await repo.update(note_id, data)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    return updated
+
+
+@router.delete("/{notebook_id}/notes/{note_id}", status_code=204)
+async def delete_note_endpoint(
+    notebook_id: str,
+    note_id: str,
+    repo: NoteRepository = Depends(get_repo),
+    current_user: str = Depends(get_current_user),
+):
+    existing = await repo.get_by_id(note_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    if existing["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    await repo.delete(note_id)

--- a/backend/src/api/routers/notes.py
+++ b/backend/src/api/routers/notes.py
@@ -37,7 +37,11 @@ async def create_note_endpoint(
     notebook = await notebook_repo.get_by_id(notebook_id)
     if notebook is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
+    if notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Forbidden")
     note = await repo.create(notebook_id, data, owner_id=current_user)
+    if note is None:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     if note["content"]:
         background_tasks.add_task(
             ingest_note,
@@ -56,6 +60,8 @@ async def list_notes_endpoint(
     notebook = await notebook_repo.get_by_id(notebook_id)
     if notebook is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
+    if notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
     return await repo.list(notebook_id)
 
 
@@ -64,10 +70,18 @@ async def get_note_endpoint(
     notebook_id: str,
     note_id: str,
     repo: NoteRepository = Depends(get_repo),
+    notebook_repo: NotebookRepository = Depends(get_notebook_repo),
     current_user: str = Depends(get_current_user),
 ):
+    notebook = await notebook_repo.get_by_id(notebook_id)
+    if notebook is None:
+        raise HTTPException(status_code=404, detail="Notebook not found")
     note = await repo.get_by_id(note_id)
     if note is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    if note["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    if note.get("notebook_id") != notebook_id:
         raise HTTPException(status_code=404, detail="Note not found")
     return note
 
@@ -84,6 +98,8 @@ async def update_note_endpoint(
 ):
     existing = await repo.get_by_id(note_id)
     if existing is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    if existing["notebook_id"] != notebook_id:
         raise HTTPException(status_code=404, detail="Note not found")
     if existing["owner_id"] != current_user:
         raise HTTPException(status_code=403, detail="Not authorized")
@@ -108,6 +124,8 @@ async def delete_note_endpoint(
 ):
     existing = await repo.get_by_id(note_id)
     if existing is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    if existing["notebook_id"] != notebook_id:
         raise HTTPException(status_code=404, detail="Note not found")
     if existing["owner_id"] != current_user:
         raise HTTPException(status_code=403, detail="Not authorized")

--- a/backend/src/lib/db/neo4j.py
+++ b/backend/src/lib/db/neo4j.py
@@ -12,6 +12,7 @@ _driver = AsyncGraphDatabase.driver(
 # only, permanently excluding syllabus scheduling data from similarity search.
 _STARTUP_CYPHER = [
     "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Notebook) REQUIRE n.id IS UNIQUE",
+    "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Note) REQUIRE n.id IS UNIQUE",
     "CREATE CONSTRAINT IF NOT EXISTS FOR (c:Chunk) REQUIRE c.id IS UNIQUE",
     "CREATE CONSTRAINT IF NOT EXISTS FOR (u:User) REQUIRE u.id IS UNIQUE",
     "CREATE CONSTRAINT IF NOT EXISTS FOR (u:User) REQUIRE u.username IS UNIQUE",
@@ -19,6 +20,14 @@ _STARTUP_CYPHER = [
     (
         "CREATE VECTOR INDEX chunk_embeddings IF NOT EXISTS "
         "FOR (c:ContentChunk) ON (c.embedding) "
+        "OPTIONS {indexConfig: {"
+        "`vector.dimensions`: 768, "
+        "`vector.similarity_function`: 'cosine'"
+        "}}"
+    ),
+    (
+        "CREATE VECTOR INDEX note_chunk_embeddings IF NOT EXISTS "
+        "FOR (c:NoteChunk) ON (c.embedding) "
         "OPTIONS {indexConfig: {"
         "`vector.dimensions`: 768, "
         "`vector.similarity_function`: 'cosine'"

--- a/backend/src/lib/repositories/chunk_repository.py
+++ b/backend/src/lib/repositories/chunk_repository.py
@@ -105,11 +105,15 @@ class ChunkRepository:
                 raise
 
     async def get_by_notebook(self, notebook_id: str) -> list[dict]:
-        """Return all chunks for a notebook, ordered by position."""
+        """Return all ContentChunks for a notebook, ordered by position.
+
+        Scoped to :ContentChunk to exclude :SyllabusChunk nodes, which carry
+        zero embeddings and must never enter vector search.
+        """
         query = """
             MATCH (nb:Notebook {id: $notebook_id})
                   -[:CONTAINS]->(d:Document)
-                  -[:HAS_CHUNK]->(c:Chunk)
+                  -[:HAS_CHUNK]->(c:ContentChunk)
             RETURN c
             ORDER BY c.position
         """

--- a/backend/src/lib/repositories/note_chunk_repository.py
+++ b/backend/src/lib/repositories/note_chunk_repository.py
@@ -1,0 +1,92 @@
+import uuid
+
+from neo4j import AsyncDriver
+
+
+def _node_to_dict(node) -> dict:
+    return dict(node)
+
+
+class NoteChunkRepository:
+    def __init__(self, driver: AsyncDriver):
+        self._driver = driver
+
+    async def create_chunks(
+        self,
+        note_id: str,
+        note_title: str,
+        chunks: list[dict],
+    ) -> list[str]:
+        """Create :NoteChunk:Chunk nodes, [:HAS_CHUNK] edges from Note, and [:NEXT] edges.
+
+        Each chunk dict must contain: text (str), embedding (list[float]), position (int).
+
+        Returns chunk IDs in position order.
+        """
+        chunk_data = [
+            {
+                "id": str(uuid.uuid4()),
+                "note_id": note_id,
+                "note_title": note_title,
+                "text": c["text"],
+                "embedding": c["embedding"],
+                "position": c["position"],
+            }
+            for c in sorted(chunks, key=lambda c: c["position"])
+        ]
+
+        create_query = """
+            UNWIND $chunks AS chunk
+            MATCH (n:Note {id: $note_id})
+            CREATE (c:Chunk:NoteChunk {
+                id: chunk.id,
+                note_id: $note_id,
+                note_title: $note_title,
+                text: chunk.text,
+                embedding: chunk.embedding,
+                position: chunk.position
+            })
+            CREATE (n)-[:HAS_CHUNK]->(c)
+            RETURN c.id AS id
+        """
+
+        next_query = """
+            MATCH (n:Note {id: $note_id})-[:HAS_CHUNK]->(c:NoteChunk)
+            WITH c ORDER BY c.position
+            WITH collect(c) AS ordered
+            UNWIND range(0, size(ordered) - 2) AS i
+            WITH ordered[i] AS prev, ordered[i + 1] AS nxt
+            MERGE (prev)-[:NEXT]->(nxt)
+        """
+
+        async with self._driver.session() as session:
+            tx = await session.begin_transaction()
+            try:
+                result = await tx.run(
+                    create_query,
+                    chunks=chunk_data,
+                    note_id=note_id,
+                    note_title=note_title,
+                )
+                records = await result.data()
+                chunk_ids = [r["id"] for r in records]
+
+                if len(chunk_ids) > 1:
+                    await tx.run(next_query, note_id=note_id)
+
+                await tx.commit()
+                return chunk_ids
+            except Exception:
+                await tx.rollback()
+                raise
+
+    async def delete_by_note(self, note_id: str) -> int:
+        """DETACH DELETE all NoteChunks for a note. Returns count deleted."""
+        query = """
+            MATCH (n:Note {id: $note_id})-[:HAS_CHUNK]->(c:NoteChunk)
+            DETACH DELETE c
+        """
+        async with self._driver.session() as session:
+            result = await session.run(query, note_id=note_id)
+            summary = await result.consume()
+            return summary.counters.nodes_deleted

--- a/backend/src/lib/repositories/note_repository.py
+++ b/backend/src/lib/repositories/note_repository.py
@@ -49,6 +49,8 @@ class NoteRepository:
                 owner_id=owner_id,
             )
             record = await result.single()
+            if record is None:
+                return None
             return _node_to_dict(record["n"])
 
     async def get_by_id(self, note_id: str) -> dict | None:

--- a/backend/src/lib/repositories/note_repository.py
+++ b/backend/src/lib/repositories/note_repository.py
@@ -1,0 +1,99 @@
+import uuid
+from datetime import datetime, timezone
+
+from neo4j import AsyncDriver
+from neo4j.time import DateTime as Neo4jDateTime
+
+from src.lib.schemas.note import NoteCreate, NoteUpdate
+
+
+def _node_to_dict(node) -> dict:
+    """Convert a Neo4j Note node to a plain dict matching NoteRead."""
+    props = dict(node)
+    for key in ("created_at", "updated_at"):
+        val = props.get(key)
+        if isinstance(val, Neo4jDateTime):
+            props[key] = val.to_native()
+    return props
+
+
+class NoteRepository:
+    def __init__(self, driver: AsyncDriver):
+        self._driver = driver
+
+    async def create(self, notebook_id: str, data: NoteCreate, owner_id: str) -> dict:
+        note_id = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        query = """
+            MATCH (nb:Notebook {id: $notebook_id})
+            CREATE (n:Note {
+                id: $id,
+                notebook_id: $notebook_id,
+                title: $title,
+                content: $content,
+                created_at: $now,
+                updated_at: $now,
+                owner_id: $owner_id
+            })
+            CREATE (nb)-[:HAS_NOTE]->(n)
+            RETURN n
+        """
+        async with self._driver.session() as session:
+            result = await session.run(
+                query,
+                notebook_id=notebook_id,
+                id=note_id,
+                title=data.title,
+                content=data.content,
+                now=now,
+                owner_id=owner_id,
+            )
+            record = await result.single()
+            return _node_to_dict(record["n"])
+
+    async def get_by_id(self, note_id: str) -> dict | None:
+        query = "MATCH (n:Note {id: $id}) RETURN n"
+        async with self._driver.session() as session:
+            result = await session.run(query, id=note_id)
+            record = await result.single()
+            if record is None:
+                return None
+            return _node_to_dict(record["n"])
+
+    async def list(self, notebook_id: str) -> list[dict]:
+        query = """
+            MATCH (nb:Notebook {id: $notebook_id})-[:HAS_NOTE]->(n:Note)
+            RETURN n ORDER BY n.created_at ASC
+        """
+        async with self._driver.session() as session:
+            result = await session.run(query, notebook_id=notebook_id)
+            return [_node_to_dict(record["n"]) async for record in result]
+
+    async def update(self, note_id: str, data: NoteUpdate) -> dict | None:
+        updates = data.model_dump(exclude_unset=True)
+        if not updates:
+            return await self.get_by_id(note_id)
+        now = datetime.now(timezone.utc)
+        query = """
+            MATCH (n:Note {id: $id})
+            SET n += $updates, n.updated_at = $updated_at
+            RETURN n
+        """
+        async with self._driver.session() as session:
+            result = await session.run(
+                query,
+                id=note_id,
+                updates=updates,
+                updated_at=now,
+            )
+            record = await result.single()
+            if record is None:
+                return None
+            return _node_to_dict(record["n"])
+
+    async def delete(self, note_id: str) -> bool:
+        query = "MATCH (n:Note {id: $id}) DETACH DELETE n"
+        async with self._driver.session() as session:
+            result = await session.run(query, id=note_id)
+            summary = await result.consume()
+            return summary.counters.nodes_deleted > 0

--- a/backend/src/lib/schemas/note.py
+++ b/backend/src/lib/schemas/note.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from datetime import datetime
+from typing import Optional
+
+
+class NoteCreate(BaseModel):
+    title: str
+    content: str = ""
+
+
+class NoteUpdate(BaseModel):
+    title: Optional[str] = None
+    content: Optional[str] = None
+
+
+class NoteRead(BaseModel):
+    id: str
+    notebook_id: str
+    title: str
+    content: str
+    created_at: datetime
+    updated_at: datetime
+    owner_id: str
+
+    model_config = {"from_attributes": True}

--- a/backend/src/services/ingestion/note_ingestion_service.py
+++ b/backend/src/services/ingestion/note_ingestion_service.py
@@ -1,0 +1,104 @@
+"""
+Note ingestion pipeline: markdown content -> chunk -> embed -> Neo4j NoteChunk nodes.
+
+Called as a FastAPI BackgroundTask after a note's content is created or updated.
+"""
+import logging
+import re
+
+from neo4j import AsyncDriver
+from llama_index.core import Document
+from llama_index.core.node_parser import SentenceSplitter
+
+from src.lib.repositories.note_chunk_repository import NoteChunkRepository
+from src.services.ingestion.ingestion_service import _embed_chunks
+from src.services.vector_store.vector_store_service import compute_note_similar_edges
+
+logger = logging.getLogger(__name__)
+
+_CHUNK_SIZE = 512
+_CHUNK_OVERLAP = 64
+
+_splitter = SentenceSplitter(chunk_size=_CHUNK_SIZE, chunk_overlap=_CHUNK_OVERLAP)
+
+# Strips markdown syntax that degrades embedding quality:
+# headers (#), bold/italic (* _ ~), inline code (`), links/images ([text](url))
+_MD_STRIP_RE = re.compile(
+    r"!\[.*?\]\(.*?\)"   # images
+    r"|\[.*?\]\(.*?\)"   # links
+    r"|```.*?```"         # fenced code blocks
+    r"|`[^`]*`"           # inline code
+    r"|#{1,6}\s?"         # headers
+    r"|[*_~]{1,3}"        # bold / italic / strikethrough
+    r"|\|",               # table pipes
+    re.DOTALL,
+)
+
+
+def _strip_markdown(text: str) -> str:
+    """Remove markdown syntax, leaving plain prose suitable for embedding."""
+    stripped = _MD_STRIP_RE.sub(" ", text)
+    # Collapse excess whitespace
+    return re.sub(r"\s{2,}", " ", stripped).strip()
+
+
+def _chunk_note(content: str) -> list[dict]:
+    """Split stripped note text into 512-token chunks with 64-token overlap.
+
+    Returns list of {text, position}.
+    """
+    plain = _strip_markdown(content)
+    if not plain:
+        return []
+
+    nodes = _splitter.get_nodes_from_documents([Document(text=plain)])
+    return [
+        {"text": node.text, "position": idx}
+        for idx, node in enumerate(nodes)
+    ]
+
+
+async def ingest_note(
+    driver: AsyncDriver,
+    note_id: str,
+    note_title: str,
+    content: str,
+    notebook_id: str,
+) -> None:
+    """Run the full ingestion pipeline for a single note.
+
+    1. Strip markdown and chunk the content
+    2. Embed chunks via Gemini
+    3. Delete stale NoteChunks for this note
+    4. Store new NoteChunk nodes with NEXT edges
+    5. Compute SIMILAR edges to ContentChunks and other NoteChunks
+    """
+    logger.info(
+        "Note ingestion started — note_id=%s notebook_id=%s", note_id, notebook_id
+    )
+
+    try:
+        chunks = _chunk_note(content)
+
+        if not chunks:
+            logger.info(
+                "Note ingestion skipped — no text after stripping — note_id=%s", note_id
+            )
+            return
+
+        chunks = await _embed_chunks(chunks)
+
+        repo = NoteChunkRepository(driver)
+        await repo.delete_by_note(note_id)
+        chunk_ids = await repo.create_chunks(note_id, note_title, chunks)
+
+        await compute_note_similar_edges(driver, chunk_ids, notebook_id)
+
+        logger.info(
+            "Note ingestion complete — note_id=%s chunks_stored=%d",
+            note_id, len(chunk_ids),
+        )
+    except Exception:
+        logger.exception(
+            "Note ingestion failed — note_id=%s notebook_id=%s", note_id, notebook_id
+        )

--- a/backend/src/services/vector_store/vector_store_service.py
+++ b/backend/src/services/vector_store/vector_store_service.py
@@ -161,13 +161,13 @@ async def compute_note_similar_edges(
                 # ------------------------------------------------------------------
                 content_result = await session.run(
                     """
-                    MATCH (src:NoteChunk {id: $chunk_id})
+                    MATCH (nb:Notebook {id: $notebook_id})-[:HAS_NOTE]->(:Note)
+                          -[:HAS_CHUNK]->(src:NoteChunk {id: $chunk_id})
                     CALL db.index.vector.queryNodes(
                         'chunk_embeddings', $top_k, src.embedding
                     ) YIELD node AS neighbour, score
                     WHERE score >= $threshold
-                    MATCH (nb:Notebook {id: $notebook_id})-[:CONTAINS]->(d:Document)
-                          -[:HAS_CHUNK]->(neighbour)
+                    MATCH (nb)-[:CONTAINS]->(d:Document)-[:HAS_CHUNK]->(neighbour)
                     RETURN neighbour.id AS neighbour_id, score
                     """,
                     chunk_id=chunk_id,
@@ -202,14 +202,14 @@ async def compute_note_similar_edges(
                 # ------------------------------------------------------------------
                 note_result = await session.run(
                     """
-                    MATCH (src:NoteChunk {id: $chunk_id})
+                    MATCH (nb:Notebook {id: $notebook_id})-[:HAS_NOTE]->(:Note)
+                          -[:HAS_CHUNK]->(src:NoteChunk {id: $chunk_id})
                     CALL db.index.vector.queryNodes(
                         'note_chunk_embeddings', $top_k, src.embedding
                     ) YIELD node AS neighbour, score
                     WHERE neighbour.id <> $chunk_id
                       AND score >= $threshold
-                    MATCH (nb:Notebook {id: $notebook_id})-[:HAS_NOTE]->(n:Note)
-                          -[:HAS_CHUNK]->(neighbour)
+                    MATCH (nb)-[:HAS_NOTE]->(n:Note)-[:HAS_CHUNK]->(neighbour)
                     RETURN neighbour.id AS neighbour_id, score
                     """,
                     chunk_id=chunk_id,

--- a/backend/src/services/vector_store/vector_store_service.py
+++ b/backend/src/services/vector_store/vector_store_service.py
@@ -122,6 +122,130 @@ async def compute_similar_edges(
     )
 
 
+async def compute_note_similar_edges(
+        driver: AsyncDriver,
+        note_chunk_ids: list[str],
+        notebook_id: str,
+) -> None:
+    """Build SIMILAR edges from NoteChunks to ContentChunks and other NoteChunks.
+
+    For each NoteChunk two passes are run:
+      a. Query chunk_embeddings (ContentChunk index) — write SIMILAR edges to
+         ContentChunks that belong to the same notebook.
+      b. Query note_chunk_embeddings (NoteChunk index) — write SIMILAR edges to
+         NoteChunks that belong to the same notebook.
+
+    Two separate index queries are required because Neo4j vector indexes are
+    per-label; there is no unified index across :ContentChunk and :NoteChunk.
+
+    Threshold: 0.80 (same as compute_similar_edges).
+    """
+    if not note_chunk_ids:
+        return
+
+    def _batches(iterable, size):
+        it = iter(iterable)
+        while True:
+            batch = list(islice(it, size))
+            if not batch:
+                break
+            yield batch
+
+    total_edges = 0
+
+    for batch in _batches(note_chunk_ids, _BATCH_SIZE):
+        async with driver.session() as session:
+            for chunk_id in batch:
+                # ------------------------------------------------------------------
+                # Pass a: NoteChunk → ContentChunk (cross-type)
+                # ------------------------------------------------------------------
+                content_result = await session.run(
+                    """
+                    MATCH (src:NoteChunk {id: $chunk_id})
+                    CALL db.index.vector.queryNodes(
+                        'chunk_embeddings', $top_k, src.embedding
+                    ) YIELD node AS neighbour, score
+                    WHERE score >= $threshold
+                    MATCH (nb:Notebook {id: $notebook_id})-[:CONTAINS]->(d:Document)
+                          -[:HAS_CHUNK]->(neighbour)
+                    RETURN neighbour.id AS neighbour_id, score
+                    """,
+                    chunk_id=chunk_id,
+                    top_k=_TOP_K,
+                    threshold=_SCORE_THRESHOLD,
+                    notebook_id=notebook_id,
+                )
+                content_records = await content_result.data()
+
+                if content_records:
+                    write_result = await session.run(
+                        """
+                        UNWIND $pairs AS pair
+                        MATCH (a:NoteChunk {id: pair.src_id})
+                        MATCH (b:ContentChunk {id: pair.neighbour_id})
+                        MERGE (a)-[r:SIMILAR]-(b)
+                          ON CREATE SET r.score = pair.score
+                          ON MATCH SET  r.score = pair.score
+                        RETURN count(r) AS edges_written
+                        """,
+                        pairs=[
+                            {"src_id": chunk_id, "neighbour_id": r["neighbour_id"], "score": r["score"]}
+                            for r in content_records
+                        ],
+                    )
+                    rec = await write_result.single()
+                    if rec:
+                        total_edges += rec["edges_written"]
+
+                # ------------------------------------------------------------------
+                # Pass b: NoteChunk → NoteChunk (same-type, cross-note)
+                # ------------------------------------------------------------------
+                note_result = await session.run(
+                    """
+                    MATCH (src:NoteChunk {id: $chunk_id})
+                    CALL db.index.vector.queryNodes(
+                        'note_chunk_embeddings', $top_k, src.embedding
+                    ) YIELD node AS neighbour, score
+                    WHERE neighbour.id <> $chunk_id
+                      AND score >= $threshold
+                    MATCH (nb:Notebook {id: $notebook_id})-[:HAS_NOTE]->(n:Note)
+                          -[:HAS_CHUNK]->(neighbour)
+                    RETURN neighbour.id AS neighbour_id, score
+                    """,
+                    chunk_id=chunk_id,
+                    top_k=_TOP_K,
+                    threshold=_SCORE_THRESHOLD,
+                    notebook_id=notebook_id,
+                )
+                note_records = await note_result.data()
+
+                if note_records:
+                    write_result = await session.run(
+                        """
+                        UNWIND $pairs AS pair
+                        MATCH (a:NoteChunk {id: pair.src_id})
+                        MATCH (b:NoteChunk {id: pair.neighbour_id})
+                        MERGE (a)-[r:SIMILAR]-(b)
+                          ON CREATE SET r.score = pair.score
+                          ON MATCH SET  r.score = pair.score
+                        RETURN count(r) AS edges_written
+                        """,
+                        pairs=[
+                            {"src_id": chunk_id, "neighbour_id": r["neighbour_id"], "score": r["score"]}
+                            for r in note_records
+                        ],
+                    )
+                    rec = await write_result.single()
+                    if rec:
+                        total_edges += rec["edges_written"]
+
+    logger.info(
+        "compute_note_similar_edges: processed %d note chunks, wrote %d SIMILAR edges",
+        len(note_chunk_ids),
+        total_edges,
+    )
+
+
 async def refresh_chunk_edges(chunk_id: str) -> None:
     """Stub — incremental SIMILAR edge refresh pending ML review.
 

--- a/backend/tests/api/test_notes.py
+++ b/backend/tests/api/test_notes.py
@@ -1,0 +1,302 @@
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from httpx import AsyncClient, ASGITransport
+
+from src.api.main import app
+from src.api.routers.notes import get_repo, get_notebook_repo, get_note_chunk_repo
+from src.lib.auth.jwt import get_current_user
+
+BASE_URL = "http://testserver"
+NOTES_URL = "/api/v1/notebooks/{notebook_id}/notes"
+NOTE_URL = "/api/v1/notebooks/{notebook_id}/notes/{note_id}"
+
+OWNER_ID = "user-abc"
+OTHER_USER_ID = "user-xyz"
+NOTEBOOK_ID = "nb-001"
+NOTE_ID = "note-001"
+
+_NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+_NOTEBOOK = {
+    "id": NOTEBOOK_ID,
+    "title": "Physics",
+    "course_code": "PHYS101",
+    "description": "",
+    "owner_id": OWNER_ID,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}
+
+_NOTE = {
+    "id": NOTE_ID,
+    "notebook_id": NOTEBOOK_ID,
+    "title": "Lecture 1",
+    "content": "Newton's laws",
+    "owner_id": OWNER_ID,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}
+
+
+def _note_repo(*, create_result=_NOTE, get_result=_NOTE, list_result=None, update_result=_NOTE):
+    repo = MagicMock()
+    repo.create = AsyncMock(return_value=create_result)
+    repo.get_by_id = AsyncMock(return_value=get_result)
+    repo.list = AsyncMock(return_value=list_result if list_result is not None else [_NOTE])
+    repo.update = AsyncMock(return_value=update_result)
+    repo.delete = AsyncMock(return_value=True)
+    return repo
+
+
+def _notebook_repo(*, notebook=_NOTEBOOK):
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=notebook)
+    return repo
+
+
+def _chunk_repo():
+    repo = MagicMock()
+    repo.delete_by_note = AsyncMock(return_value=None)
+    return repo
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=BASE_URL) as c:
+        yield c
+
+
+def _override(note_repo=None, notebook=_NOTEBOOK, current_user=OWNER_ID):
+    app.dependency_overrides[get_repo] = lambda: note_repo or _note_repo()
+    app.dependency_overrides[get_notebook_repo] = lambda: _notebook_repo(notebook=notebook)
+    app.dependency_overrides[get_note_chunk_repo] = lambda: _chunk_repo()
+    app.dependency_overrides[get_current_user] = lambda: current_user
+
+
+def _clear():
+    for dep in (get_repo, get_notebook_repo, get_note_chunk_repo, get_current_user):
+        app.dependency_overrides.pop(dep, None)
+
+
+# ---------------------------------------------------------------------------
+# POST /{notebook_id}/notes
+# ---------------------------------------------------------------------------
+
+
+async def test_create_note_owned_notebook_returns_201(client):
+    _override()
+    try:
+        resp = await client.post(
+            NOTES_URL.format(notebook_id=NOTEBOOK_ID),
+            json={"title": "Lecture 1", "content": "Newton's laws"},
+        )
+    finally:
+        _clear()
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["id"] == NOTE_ID
+    assert body["notebook_id"] == NOTEBOOK_ID
+
+
+async def test_create_note_unowned_notebook_returns_403(client):
+    _override(current_user=OTHER_USER_ID)
+    try:
+        resp = await client.post(
+            NOTES_URL.format(notebook_id=NOTEBOOK_ID),
+            json={"title": "Lecture 1", "content": "Newton's laws"},
+        )
+    finally:
+        _clear()
+
+    assert resp.status_code == 403
+
+
+async def test_create_note_missing_notebook_returns_404(client):
+    _override(notebook=None)
+    try:
+        resp = await client.post(
+            NOTES_URL.format(notebook_id="nonexistent"),
+            json={"title": "Lecture 1", "content": "Newton's laws"},
+        )
+    finally:
+        _clear()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /{notebook_id}/notes
+# ---------------------------------------------------------------------------
+
+
+async def test_list_notes_owned_notebook_returns_200(client):
+    _override()
+    try:
+        resp = await client.get(NOTES_URL.format(notebook_id=NOTEBOOK_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+async def test_list_notes_unowned_notebook_returns_403(client):
+    _override(current_user=OTHER_USER_ID)
+    try:
+        resp = await client.get(NOTES_URL.format(notebook_id=NOTEBOOK_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 403
+
+
+async def test_list_notes_missing_notebook_returns_404(client):
+    _override(notebook=None)
+    try:
+        resp = await client.get(NOTES_URL.format(notebook_id="nonexistent"))
+    finally:
+        _clear()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /{notebook_id}/notes/{note_id}
+# ---------------------------------------------------------------------------
+
+
+async def test_get_note_returns_200(client):
+    _override()
+    try:
+        resp = await client.get(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == NOTE_ID
+
+
+async def test_get_note_wrong_owner_returns_403(client):
+    _override(current_user=OTHER_USER_ID)
+    try:
+        resp = await client.get(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 403
+
+
+async def test_get_note_wrong_notebook_returns_404(client):
+    note_in_other_notebook = {**_NOTE, "notebook_id": "other-nb"}
+    _override(note_repo=_note_repo(get_result=note_in_other_notebook))
+    try:
+        resp = await client.get(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 404
+
+
+async def test_get_note_not_found_returns_404(client):
+    _override(note_repo=_note_repo(get_result=None))
+    try:
+        resp = await client.get(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id="missing"))
+    finally:
+        _clear()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /{notebook_id}/notes/{note_id}
+# ---------------------------------------------------------------------------
+
+
+async def test_update_note_owned_returns_200(client):
+    _override()
+    try:
+        resp = await client.patch(
+            NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID),
+            json={"title": "Updated title"},
+        )
+    finally:
+        _clear()
+
+    assert resp.status_code == 200
+
+
+async def test_update_note_unowned_returns_403(client):
+    _override(current_user=OTHER_USER_ID)
+    try:
+        resp = await client.patch(
+            NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID),
+            json={"title": "Hacked"},
+        )
+    finally:
+        _clear()
+
+    assert resp.status_code == 403
+
+
+async def test_update_note_wrong_notebook_returns_404(client):
+    note_in_other_notebook = {**_NOTE, "notebook_id": "other-nb"}
+    _override(note_repo=_note_repo(get_result=note_in_other_notebook))
+    try:
+        resp = await client.patch(
+            NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID),
+            json={"title": "Cross-notebook update"},
+        )
+    finally:
+        _clear()
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /{notebook_id}/notes/{note_id}
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_note_owned_returns_204(client):
+    _override()
+    try:
+        resp = await client.delete(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 204
+
+
+async def test_delete_note_unowned_returns_403(client):
+    _override(current_user=OTHER_USER_ID)
+    try:
+        resp = await client.delete(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 403
+
+
+async def test_delete_note_wrong_notebook_returns_404(client):
+    note_in_other_notebook = {**_NOTE, "notebook_id": "other-nb"}
+    _override(note_repo=_note_repo(get_result=note_in_other_notebook))
+    try:
+        resp = await client.delete(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id=NOTE_ID))
+    finally:
+        _clear()
+
+    assert resp.status_code == 404
+
+
+async def test_delete_note_not_found_returns_404(client):
+    _override(note_repo=_note_repo(get_result=None))
+    try:
+        resp = await client.delete(NOTE_URL.format(notebook_id=NOTEBOOK_ID, note_id="missing"))
+    finally:
+        _clear()
+
+    assert resp.status_code == 404

--- a/docs/notebook-storage-plan.md
+++ b/docs/notebook-storage-plan.md
@@ -1,0 +1,436 @@
+# Plan: Persistent Note Storage for NoteBud
+
+## Role Constraint
+
+> **Backend engineer only.** All implementation work is scoped to the backend (`backend/`). The Frontend Work section and API Contract are specifications for the frontend team — treat them as read-only reference. Do not modify any files under `frontend/`.
+>
+> **Commit cadence.** After each task is completed, create a git commit before starting the next one. Use the format: `S6-XX: <title>`.
+
+---
+
+## Status
+
+The notes workspace (`/backpack/[id]/notes/page.tsx`) currently has tab management in React state only — tabs are ephemeral and note content is a placeholder `<div>`. No `Note` model exists in the backend. The `Notebook` model holds metadata; `Document` holds uploaded files. A first-class `Note` entity is needed that persists the user's typed markdown across sessions, with per-tab autosave.
+
+---
+
+## Storage Architecture Decision
+
+### Note content stored directly in Neo4j `:Note` node
+- Each `:Note` node stores `content` (markdown string) as a node property
+- Relationship: `(:Notebook)-[:HAS_NOTE]->(:Note)`
+- Markdown text is small (rarely >100 KB), Neo4j handles it fine. Single Cypher query for read/write — much lower latency than a GCS round-trip. Autosave fires on a debounce (every ~1–2 s); GCS latency would make this feel laggy.
+
+### Images within notes
+- Images are the exception: they can be large and binary
+- Store image files in GCS (same bucket, `notes/images/` prefix)
+- Reference them in markdown as a relative or absolute URL (`![alt](/api/v1/notes/images/{id})` or signed GCS URL)
+- The `Note` node itself stores only the markdown text (with image URL references), not raw binary
+
+---
+
+## Data Model
+
+### Neo4j `:Note` node properties
+```
+id            : UUID string
+notebook_id   : string (denormalized for fast lookup)
+title         : string (user-editable tab label)
+content       : string (markdown body)
+created_at    : datetime
+updated_at    : datetime
+owner_id      : string
+```
+
+### Relationship
+```
+(:Notebook {id})-[:HAS_NOTE]->(:Note {id})
+```
+
+---
+
+## Backend Work
+
+### 1. Pydantic Schemas — `backend/src/lib/schemas/note.py` (new file)
+```python
+class NoteCreate(BaseModel):
+    title: str
+    content: str = ""
+
+class NoteUpdate(BaseModel):
+    title: Optional[str] = None
+    content: Optional[str] = None
+
+class NoteRead(BaseModel):
+    id: str
+    notebook_id: str
+    title: str
+    content: str
+    created_at: datetime
+    updated_at: datetime
+    owner_id: str
+```
+
+### 2. Repository — `backend/src/lib/repositories/note_repository.py` (new file)
+CRUD mirroring `NotebookRepository`:
+- `create(notebook_id, data, owner_id)` — creates `:Note` node + `[:HAS_NOTE]` edge
+- `get_by_id(note_id)` — single node fetch
+- `list(notebook_id)` — all notes for a notebook, ordered by `created_at`
+- `update(note_id, data)` — partial update via `SET n += $updates`
+- `delete(note_id)` — `DETACH DELETE`
+
+### 3. Router — `backend/src/api/routers/notes.py` (new file)
+```
+POST   /api/v1/notebooks/{notebook_id}/notes          → create note
+GET    /api/v1/notebooks/{notebook_id}/notes          → list notes
+GET    /api/v1/notebooks/{notebook_id}/notes/{id}     → get note
+PATCH  /api/v1/notebooks/{notebook_id}/notes/{id}     → update note (autosave)
+DELETE /api/v1/notebooks/{notebook_id}/notes/{id}     → delete note
+```
+Authorization: verify `owner_id == current_user` on all mutating endpoints (same pattern as `notebooks.py`).
+
+### 4. Register router in `backend/src/api/main.py`
+Add `from src.api.routers import notes` and `app.include_router(notes.router)`.
+
+---
+
+## Frontend Work
+
+### 5. API layer — `frontend/src/lib/api/notes.ts` (new file)
+Axios calls for all 5 endpoints, typed with `NoteRead`/`NoteCreate`/`NoteUpdate`.
+
+### 6. React Query hook — `frontend/src/hooks/useNotes.ts` (new file)
+- `useNotes(notebookId)` — list query
+- `useNote(noteId)` — single note query (load content when tab is selected)
+- `useCreateNote()` — mutation, called when user adds a tab
+- `useUpdateNote()` — mutation, called by autosave
+- `useDeleteNote()` — mutation, called when user closes a tab
+
+### 7. Autosave in notes page — `frontend/src/app/backpack/[id]/notes/page.tsx`
+- Replace hardcoded `tabs` state with data from `useNotes(notebookId)`
+- Track `activeNoteId` (UUID) instead of `activeTab` (string label)
+- Debounce `useUpdateNote` mutation: fire 1.5 s after the user stops typing
+- Show a subtle "Saving…" / "Saved" indicator in the tab bar or editor header
+
+### 8. Tab state shape change
+Each tab becomes a `NoteRead` object. `NotesTabs.tsx` receives `notes: NoteRead[]` and `activeNoteId: string` instead of `tabs: string[]`.
+
+---
+
+## API Contract
+
+All endpoints are nested under `/api/v1/notebooks/{notebook_id}/notes` and require a Bearer token (`Authorization: Bearer <jwt>`).
+
+### POST `/api/v1/notebooks/{notebook_id}/notes`
+Create a new note (fires when the user adds a tab).
+
+**Request body**
+```json
+{
+  "title": "Notes-1",
+  "content": ""
+}
+```
+**Response `201`**
+```json
+{
+  "id": "uuid",
+  "notebook_id": "uuid",
+  "title": "Notes-1",
+  "content": "",
+  "created_at": "2026-04-01T10:00:00Z",
+  "updated_at": "2026-04-01T10:00:00Z",
+  "owner_id": "user-uuid"
+}
+```
+**Errors:** `401` unauthenticated, `404` notebook not found.
+
+---
+
+### GET `/api/v1/notebooks/{notebook_id}/notes`
+List all notes for a notebook (called on page load to restore tabs).
+
+**Response `200`**
+```json
+[
+  { "id": "...", "title": "Notes-1", "content": "...", "created_at": "...", "updated_at": "...", "notebook_id": "...", "owner_id": "..." },
+  { "id": "...", "title": "Notes-2", "content": "...", "created_at": "...", "updated_at": "...", "notebook_id": "...", "owner_id": "..." }
+]
+```
+Ordered by `created_at ASC` so tabs restore in original order.
+
+**Errors:** `401`, `404`.
+
+---
+
+### GET `/api/v1/notebooks/{notebook_id}/notes/{note_id}`
+Fetch a single note (available for targeted refresh; not required on initial load since list returns full content).
+
+**Response `200`** — same shape as a single item from the list response.
+
+**Errors:** `401`, `404`.
+
+---
+
+### PATCH `/api/v1/notebooks/{notebook_id}/notes/{note_id}`
+Partial update — the autosave endpoint. Only send fields that changed.
+
+**Request body** (all fields optional)
+```json
+{
+  "title": "Renamed Tab",
+  "content": "# My Notes\n\nSome content here..."
+}
+```
+**Response `200`** — full updated `NoteRead` object.
+
+**Errors:** `401`, `403` (not owner), `404`.
+
+**Frontend behaviour:** debounced 1 500 ms after last keystroke. Fires silently; UI shows "Saving…" → "Saved" in the tab bar.
+
+---
+
+### DELETE `/api/v1/notebooks/{notebook_id}/notes/{note_id}`
+Delete a note (fires when user closes a tab).
+
+**Response `204`** — no body.
+
+**Errors:** `401`, `403`, `404`.
+
+---
+
+### Image upload — POST `/api/v1/notebooks/{notebook_id}/notes/{note_id}/images`
+*(Future endpoint — not in this sprint.)*
+Accepts `multipart/form-data` with a single image file. Stores in GCS under `notes/images/{note_id}/{filename}`. Returns a signed URL or a `/api/v1/...` proxy path that the editor inserts as a markdown image reference.
+
+---
+
+## Critical Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/src/lib/schemas/note.py` | **Create** — Pydantic schemas |
+| `backend/src/lib/repositories/note_repository.py` | **Create** — Cypher CRUD |
+| `backend/src/api/routers/notes.py` | **Create** — REST endpoints |
+| `backend/src/api/main.py` | Register new notes router |
+| `frontend/src/lib/api/notes.ts` | **Create** — Axios API layer |
+| `frontend/src/hooks/useNotes.ts` | **Create** — React Query hooks |
+| `frontend/src/app/backpack/[id]/notes/page.tsx` | Wire tabs to real notes, add autosave |
+| `frontend/src/components/NotesTabs.tsx` | Accept `NoteRead[]` instead of `string[]` |
+
+### Existing patterns to reuse
+- `NotebookRepository` (`backend/src/lib/repositories/notebook_repository.py`) — copy the `_node_to_dict` helper and session pattern
+- Notebooks router (`backend/src/api/routers/notebooks.py`) — copy ownership auth check pattern
+- `useNotebooks` hook (`frontend/src/hooks/useNotebooks.ts`) — copy React Query structure
+- Auth header injection via `client.ts` Axios instance — already configured
+
+---
+
+## Verification — Note Storage
+
+1. **Backend unit test:** Call `POST /api/v1/notebooks/{id}/notes`, then `GET` the same note, assert content matches.
+2. **Autosave test:** Open the notes page, type in the editor, wait 2 s, hard-refresh the browser — note content should persist.
+3. **Tab persistence test:** Create 3 tabs, close the browser, reopen — all 3 tabs should reappear with their content.
+4. **Delete test:** Close a tab → `DELETE` fires → note is gone from DB and doesn't reappear on refresh.
+5. **Auth test:** Attempt to `PATCH` a note owned by another user → expect `403`.
+
+---
+
+# Plan: Note GraphRAG Integration
+
+## Context
+
+The current GraphRAG pipeline retrieves answers exclusively from uploaded document chunks (`:ContentChunk` nodes). User-written notes (`:Note` nodes — just built) are disconnected from the retrieval graph. This plan integrates notes into GraphRAG so that when a user queries their notebook, the AI draws on **both** their uploaded documents and their own written notes, with cross-type similarity edges connecting the two.
+
+---
+
+## Graph Schema Additions
+
+### New node label: `:NoteChunk` (sub-label of `:Chunk`)
+Follows the existing convention — every chunk node carries `:Chunk` + a type label.
+
+```
+(:Note)-[:HAS_CHUNK]->(:NoteChunk:Chunk)
+```
+
+**Properties** (same as `:ContentChunk` plus `note_id` and `note_title`):
+```
+id           : UUID string
+note_id      : string (denormalized — fast lookup, cascade delete)
+note_title   : string (for citation display)
+text         : string (chunk text, stripped of heavy markdown syntax)
+embedding    : vector(768)
+position     : int (0-based, for NEXT edges)
+```
+
+### New edges
+```
+(:Note)-[:HAS_CHUNK]->(:NoteChunk:Chunk)    — ownership (mirrors Document→ContentChunk)
+(:NoteChunk)-[:NEXT]->(:NoteChunk)          — sequential order within a note
+(:NoteChunk)-[:SIMILAR]-(:ContentChunk)     — cross-type similarity (KEY GRAPH CONNECTION)
+(:NoteChunk)-[:SIMILAR]-(:NoteChunk)        — similarity between chunks across notes
+```
+
+### New unique constraint
+```cypher
+CREATE CONSTRAINT IF NOT EXISTS FOR (n:Note) REQUIRE n.id IS UNIQUE
+```
+Missing from current DDL in `backend/src/lib/db/neo4j.py` — needs to be added.
+
+### New vector index
+```cypher
+CREATE VECTOR INDEX note_chunk_embeddings IF NOT EXISTS
+FOR (c:NoteChunk) ON (c.embedding)
+OPTIONS {indexConfig: {`vector.dimensions`: 768, `vector.similarity_function`: 'cosine'}}
+```
+
+---
+
+## Files to Create
+
+### 1. `backend/src/lib/repositories/note_chunk_repository.py`
+
+```python
+create_chunks(note_id, note_title, chunks) -> list[str]
+    # Creates :NoteChunk:Chunk nodes + [:HAS_CHUNK] edge from Note + [:NEXT] edges
+    # Mirrors ChunkRepository.create_chunks() exactly
+
+delete_by_note(note_id) -> int
+    # DETACH DELETE all NoteChunks for a note (called before re-indexing on save)
+    # MATCH (n:Note {id: $note_id})-[:HAS_CHUNK]->(c:NoteChunk) DETACH DELETE c
+```
+
+### 2. `backend/src/services/ingestion/note_ingestion_service.py`
+
+Full pipeline triggered as a BackgroundTask on note save:
+
+```python
+async def ingest_note(driver, note_id, note_title, content, notebook_id) -> None:
+    # 1. Strip heavy markdown syntax (headers, bold, links) → plain text for embedding
+    # 2. Chunk with same SentenceSplitter(512, 64) as document pipeline
+    # 3. Embed with Gemini (reuse _embed_chunks from ingestion_service.py)
+    # 4. delete_by_note(note_id)           — delete stale NoteChunks
+    # 5. create_chunks(note_id, ...)        — write new NoteChunk nodes
+    # 6. compute_note_similar_edges(driver, new_chunk_ids, notebook_id)
+```
+
+**Markdown stripping:** use `re.sub` to strip `#`, `*`, `_`, `` ` ``, `[]()` before embedding. Store the original markdown in `:Note.content`; store stripped text in `:NoteChunk.text` for embedding accuracy.
+
+**Empty note guard:** if content is blank or produces no chunks after stripping, skip ingestion silently.
+
+---
+
+## Files to Modify
+
+### 3. `backend/src/services/vector_store/vector_store_service.py`
+
+Add `compute_note_similar_edges()`:
+
+```python
+async def compute_note_similar_edges(
+    driver, note_chunk_ids, notebook_id
+) -> None:
+    """Build cross-type SIMILAR edges from NoteChunks to ContentChunks and other NoteChunks.
+
+    For each NoteChunk:
+      a. Query chunk_embeddings (ContentChunk index) — write SIMILAR to matching ContentChunks
+         in the same notebook only (scoped via MATCH (nb:Notebook)-[:CONTAINS]->...)
+      b. Query note_chunk_embeddings (NoteChunk index) — write SIMILAR to matching NoteChunks
+         in the same notebook only (scoped via MATCH (nb:Notebook)-[:HAS_NOTE]->...)
+    Threshold: 0.80 (same as existing compute_similar_edges)
+    """
+```
+
+Two separate index queries are required because Neo4j vector indexes are per-label — there is no unified index across `:ContentChunk` and `:NoteChunk`.
+
+### 4. `backend/src/lib/db/neo4j.py`
+
+Add to `_STARTUP_CYPHER`:
+
+```python
+"CREATE CONSTRAINT IF NOT EXISTS FOR (n:Note) REQUIRE n.id IS UNIQUE",
+(
+    "CREATE VECTOR INDEX note_chunk_embeddings IF NOT EXISTS "
+    "FOR (c:NoteChunk) ON (c.embedding) "
+    "OPTIONS {indexConfig: {"
+    "`vector.dimensions`: 768, "
+    "`vector.similarity_function`: 'cosine'"
+    "}}"
+),
+```
+
+### 5. `backend/src/api/routers/notes.py`
+
+Trigger `ingest_note` as a BackgroundTask **only when `content` changed**:
+
+```python
+from fastapi import BackgroundTasks
+from src.services.ingestion.note_ingestion_service import ingest_note
+
+@router.patch("/{notebook_id}/notes/{note_id}")
+async def update_note_endpoint(..., background_tasks: BackgroundTasks):
+    ...
+    updated = await repo.update(note_id, data)
+    if "content" in data.model_dump(exclude_unset=True):
+        background_tasks.add_task(
+            ingest_note,
+            driver, note_id, updated["title"], updated["content"], notebook_id
+        )
+    return updated
+```
+
+Also wire BackgroundTask on `create_note_endpoint` (empty content → ingestion is a no-op, hook is ready for when content arrives).
+
+### 6. `backend/src/lib/repositories/chunk_repository.py`
+
+Fix `get_by_notebook()` label bug (Task 1 of impl guide): change `:Chunk` → `:ContentChunk`. Required so retrieval expansion doesn't accidentally traverse `:NoteChunk` nodes through the wrong path.
+
+---
+
+## How This Feeds Into Retrieval
+
+When `search_similar()` is implemented (Task 6 of impl guide), it should query **both** indexes and merge results:
+
+```python
+# Query 1: ContentChunks matching the user's question
+CALL db.index.vector.queryNodes('chunk_embeddings', $top_k, $query_embedding)
+
+# Query 2: NoteChunks matching the user's question
+CALL db.index.vector.queryNodes('note_chunk_embeddings', $top_k, $query_embedding)
+
+# Merge, re-rank by score, take top-K overall
+```
+
+The graph walk (Task 7) then **automatically** traverses cross-type SIMILAR edges — a ContentChunk seed walks to NoteChunks and vice versa — without any special-casing. This is the GraphRAG payoff.
+
+**Citation shape** will need a `source_type` field (`"document"` vs `"note"`) and `note_title` for NoteChunk citations (replacing `source_file`).
+
+---
+
+## Delete Cascade
+
+When a `:Note` is deleted, `NoteRepository.delete()` already uses `DETACH DELETE`. Add an explicit pre-delete of NoteChunks via `NoteChunkRepository.delete_by_note()` before the DETACH DELETE to ensure SIMILAR edges to ContentChunks are also cleaned up.
+
+---
+
+## Critical Files Summary
+
+| File | Action |
+|------|--------|
+| `backend/src/lib/db/neo4j.py` | Add `:Note` constraint + `note_chunk_embeddings` index |
+| `backend/src/lib/repositories/note_chunk_repository.py` | **Create** — NoteChunk CRUD |
+| `backend/src/services/ingestion/note_ingestion_service.py` | **Create** — note chunk/embed/store pipeline |
+| `backend/src/services/vector_store/vector_store_service.py` | Add `compute_note_similar_edges()` |
+| `backend/src/api/routers/notes.py` | Trigger `ingest_note` as BackgroundTask on PATCH/POST |
+| `backend/src/lib/repositories/chunk_repository.py` | Fix `get_by_notebook()` label: `:Chunk` → `:ContentChunk` |
+
+---
+
+## Verification — GraphRAG Integration
+
+1. **Schema test:** After startup, confirm `note_chunk_embeddings` index and `:Note` constraint exist in Neo4j browser.
+2. **Ingest test:** Save a note with content → confirm `:NoteChunk` nodes appear linked via `[:HAS_CHUNK]` from the `:Note` node.
+3. **SIMILAR edge test:** Confirm `:SIMILAR` edges exist between NoteChunks and ContentChunks in the same notebook (requires at least one document also ingested).
+4. **Re-index test:** Edit note content → confirm old NoteChunks are deleted and new ones created.
+5. **Delete test:** Delete a note → confirm all NoteChunks and their SIMILAR edges are removed.
+6. **Empty note test:** Save a note with no content → confirm no NoteChunks are created, no error raised.


### PR DESCRIPTION
- [x] Understand all review comments
- [x] Fix `create_note_endpoint`: add ownership check on notebook (403 for non-owners)
- [x] Fix `list_notes_endpoint`: add ownership check on notebook (403 for non-owners)
- [x] Fix `get_note_endpoint`: add notebook_repo dep, verify ownership + notebook scoping (403/404)
- [x] Fix `update_note_endpoint`: verify note belongs to `notebook_id` path param (404 on mismatch)
- [x] Fix `delete_note_endpoint`: verify note belongs to `notebook_id` path param (404 on mismatch)
- [x] Fix `NoteRepository.create`: handle None record (race-condition safety)
- [x] Fix `compute_note_similar_edges`: scope `src:NoteChunk` to the notebook in both passes
- [x] Add API tests for notes endpoints (17 tests: create/list/get/update/delete with authz checks and notebook scoping)