### PR TITLE
feat: RAG chat endpoint with citations & streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,8 @@ git push origin feature/your-feature-name
 - At least one team member must review before merging
 - Squash and merge on approval
 
-curl -N -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzN2MwZWViNC01MTQ5LTQ5ZmYtYTQzYS0wNjNmZjgwYjU0M2EiLCJ1c2VybmFtZSI6ImNlc2FyIiwiZXhwIjoxNzc1MzI1OTQ1fQ.GYf1u6uZD2v6j-mDTZuvLngoohDEi2EeuW50OGyIwU0" -H "Content-Type: application/json" -d '{"query": "What is this document about?"}' http://localhost:8000/api/v1/notebooks/bf0b5197-2f00-4077-a3ad-8e1a7e3e6eb9/chat
+```bash
+curl -N -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"query": "What is this document about?"}' \
+  http://localhost:8000/api/v1/notebooks/$NOTEBOOK_ID/chat
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ it.**
 ## 🛠️ Tech Stack
 
 ### Frontend
+
 - **React / Next.js** — UI framework, routing, server-side rendering
 - **TypeScript** — Type safety
 - **Tailwind CSS** — Styling
@@ -28,18 +29,21 @@ it.**
 - **Axios** — HTTP client
 
 ### Backend
+
 - **FastAPI** — Python REST API
 - **Neo4j** — Graph store for notebooks, documents, chunks, and course relationships; vector index on content chunks
 - **neo4j-graphrag** — Graph RAG utilities
 - **Pydantic** — Request and response validation
 
 ### AI / ML
+
 - **Gemini API** — LLM for answer generation and embeddings
 - **Google ADK / LangGraph** — Agent orchestration
 - **LlamaIndex / LangChain** — Document loading, chunking, RAG pipeline
 - **scikit-learn / PyTorch** — ML model training
 
 ### Infrastructure
+
 - **Docker + Docker Compose** — Containerization and local dev
 - **GCS / S3** — Cloud object storage
 - **GitHub Actions** — CI/CD
@@ -50,6 +54,7 @@ it.**
 ## 🚀 Getting Started
 
 ### Prerequisites
+
 - Docker & Docker Compose
 - Node.js (for frontend)
 - Python 3.10+ (for backend)
@@ -98,13 +103,13 @@ Architecture overview: [docs/notes-workspace-ui-architecture.md](docs/notes-work
 
 ### Branch Structure
 
-| Branch | Purpose |
-|---|---|
-| `main` | Production-ready, always deployable, protected |
-| `dev` | Integration branch for features |
-| `feature/*` | Individual feature development |
-| `bugfix/*` | Bug fixes |
-| `hotfix/*` | Emergency production fixes |
+| Branch      | Purpose                                        |
+| ----------- | ---------------------------------------------- |
+| `main`      | Production-ready, always deployable, protected |
+| `dev`       | Integration branch for features                |
+| `feature/*` | Individual feature development                 |
+| `bugfix/*`  | Bug fixes                                      |
+| `hotfix/*`  | Emergency production fixes                     |
 
 ### Contributing
 
@@ -128,7 +133,10 @@ git push origin feature/your-feature-name
 ```
 
 **PR Guidelines:**
+
 - Target `dev`, never `main`
 - Keep PRs small and focused
 - At least one team member must review before merging
 - Squash and merge on approval
+
+curl -N -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzN2MwZWViNC01MTQ5LTQ5ZmYtYTQzYS0wNjNmZjgwYjU0M2EiLCJ1c2VybmFtZSI6ImNlc2FyIiwiZXhwIjoxNzc1MzI1OTQ1fQ.GYf1u6uZD2v6j-mDTZuvLngoohDEi2EeuW50OGyIwU0" -H "Content-Type: application/json" -d '{"query": "What is this document about?"}' http://localhost:8000/api/v1/notebooks/bf0b5197-2f00-4077-a3ad-8e1a7e3e6eb9/chat

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,3 +16,5 @@ JWT_SECRET=
 
 # CORS — JSON array of allowed origins; defaults to http://localhost:3000 and http://127.0.0.1:3000 if omitted
 ALLOWED_ORIGINS=["http://localhost:3000", "http://127.0.0.1:3000"]
+
+GEMINI_MODEL=your_gemini_model

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from src.lib.config.settings import settings
 from src.lib.db.neo4j import startup, close_driver
-from src.api.routers import health, files, notebooks, query, courses, auth
+from src.api.routers import health, files, notebooks, query, chat, courses, auth
 
 
 @asynccontextmanager
@@ -55,6 +55,12 @@ app.include_router(
     query.router,
     prefix=f"{settings.API_V1_STR}/notebooks",
     tags=["Query"],
+)
+
+app.include_router(
+    chat.router,
+    prefix=f"{settings.API_V1_STR}/notebooks",
+    tags=["Chat"],
 )
 
 app.include_router(

--- a/backend/src/api/routers/chat.py
+++ b/backend/src/api/routers/chat.py
@@ -25,10 +25,8 @@ async def chat_notebook(
 ):
     """Stream a RAG-powered chat answer with citations via SSE."""
     notebook = await NotebookRepository(driver).get_by_id(notebook_id)
-    if notebook is None:
+    if notebook is None or notebook["owner_id"] != current_user:
         raise HTTPException(status_code=404, detail="Notebook not found")
-    if notebook["owner_id"] != current_user:
-        raise HTTPException(status_code=403, detail="Not authorized")
 
     return StreamingResponse(
         rag_service.stream_chat(notebook_id, body.query),

--- a/backend/src/api/routers/chat.py
+++ b/backend/src/api/routers/chat.py
@@ -25,8 +25,10 @@ async def chat_notebook(
 ):
     """Stream a RAG-powered chat answer with citations via SSE."""
     notebook = await NotebookRepository(driver).get_by_id(notebook_id)
-    if notebook is None or notebook["owner_id"] != current_user:
+    if notebook is None:
         raise HTTPException(status_code=404, detail="Notebook not found")
+    if notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
 
     return StreamingResponse(
         rag_service.stream_chat(notebook_id, body.query),

--- a/backend/src/api/routers/chat.py
+++ b/backend/src/api/routers/chat.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from neo4j import AsyncDriver
+
+from src.lib.auth.jwt import get_current_user
+from src.lib.db.neo4j import get_driver
+from src.lib.repositories.notebook_repository import NotebookRepository
+from src.lib.schemas.chat import ChatRequest
+from src.services.rag.graph_rag_service import GraphRAGService
+
+router = APIRouter()
+
+
+def get_rag_service(driver: AsyncDriver = Depends(get_driver)) -> GraphRAGService:
+    return GraphRAGService(driver)
+
+
+@router.post("/{notebook_id}/chat")
+async def chat_notebook(
+    notebook_id: str,
+    body: ChatRequest,
+    driver: AsyncDriver = Depends(get_driver),
+    rag_service: GraphRAGService = Depends(get_rag_service),
+    current_user: str = Depends(get_current_user),
+):
+    """Stream a RAG-powered chat answer with citations via SSE."""
+    notebook = await NotebookRepository(driver).get_by_id(notebook_id)
+    if notebook is None or notebook["owner_id"] != current_user:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+
+    return StreamingResponse(
+        rag_service.stream_chat(notebook_id, body.query),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/src/lib/config/settings.py
+++ b/backend/src/lib/config/settings.py
@@ -37,6 +37,11 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("GEMINI_API_KEY", "gemini_api_key"),
     )
 
+    gemini_model: str = Field(
+        default="gemini-2.0-flash",
+        validation_alias=AliasChoices("GEMINI_MODEL", "gemini_model"),
+    )
+
     model_config = SettingsConfigDict(
         env_file=(".env", f".env.{os.getenv('ENVIRONMENT', 'development')}"),
         env_file_encoding="utf-8",

--- a/backend/src/lib/schemas/chat.py
+++ b/backend/src/lib/schemas/chat.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class ChatRequest(BaseModel):
+    query: str
+
+
+class Citation(BaseModel):
+    chunk_id: str
+    filename: str
+    snippet: str

--- a/backend/src/lib/schemas/chat.py
+++ b/backend/src/lib/schemas/chat.py
@@ -3,9 +3,3 @@ from pydantic import BaseModel
 
 class ChatRequest(BaseModel):
     query: str
-
-
-class Citation(BaseModel):
-    chunk_id: str
-    filename: str
-    snippet: str

--- a/backend/src/services/rag/graph_rag_service.py
+++ b/backend/src/services/rag/graph_rag_service.py
@@ -1,14 +1,281 @@
+"""
+RAG chat service: embed query -> retrieve chunks -> stream LLM answer with citations.
+"""
+
+import asyncio
+import json
+import logging
+import threading
+from typing import AsyncGenerator
+
+import anyio
+from google import genai
+from google.genai import errors as genai_errors
 from neo4j import AsyncDriver
+
+from src.lib.config.settings import settings
+from src.services.ingestion.ingestion_service import (
+    EMBEDDING_DIMENSIONS,
+    EMBEDDING_MODEL,
+    _EMBED_BACKOFF_BASE,
+    _EMBED_MAX_RETRIES,
+)
+
+logger = logging.getLogger(__name__)
+
+_VECTOR_INDEX = "chunk_embeddings"
+_RETRIEVAL_TOP_K = 20  # cast a wide net, then filter by notebook
+_RESULT_LIMIT = 5
+_SIMILARITY_FLOOR = 0.50  # minimum to include a chunk at all
+_CONFIDENCE_THRESHOLD = 0.75  # for the low_confidence flag
+_MIN_CONFIDENT_CHUNKS = 2
+
+_SYSTEM_INSTRUCTION = (
+    "You are a helpful study assistant. Answer the user's question based ONLY "
+    "on the provided context from their notebook documents. If the context "
+    "doesn't contain enough information to answer the question, say so clearly. "
+    "Be concise and accurate."
+)
+
+
+def _get_genai_client() -> genai.Client:
+    api_key = settings.gemini_api_key
+    if not api_key:
+        raise EnvironmentError(
+            "GEMINI_API_KEY is not set — required for RAG chat"
+        )
+    return genai.Client(api_key=api_key)
+
+
+def _embed_query_sync(client: genai.Client, text: str) -> list[float]:
+    """Embed a single query string (blocking). Retries on transient errors."""
+    import time
+
+    for attempt in range(_EMBED_MAX_RETRIES):
+        try:
+            response = client.models.embed_content(
+                model=EMBEDDING_MODEL,
+                contents=text,
+                config={"output_dimensionality": EMBEDDING_DIMENSIONS},
+            )
+            return response.embeddings[0].values
+        except (genai_errors.ServerError, genai_errors.ClientError) as exc:
+            retryable = isinstance(exc, genai_errors.ServerError) or "429" in str(exc)
+            if retryable and attempt < _EMBED_MAX_RETRIES - 1:
+                time.sleep(_EMBED_BACKOFF_BASE * (2 ** attempt))
+                continue
+            raise
+    raise RuntimeError("EMBEDDING_FAILED: max retries exceeded")
 
 
 class GraphRAGService:
-    """Stub — full implementation by ML team in S3-18."""
-
     def __init__(self, driver: AsyncDriver):
         self._driver = driver
 
+    # ------------------------------------------------------------------
+    # 1. Embed the user query
+    # ------------------------------------------------------------------
+    async def _embed_query(self, query_text: str) -> list[float]:
+        client = _get_genai_client()
+        return await anyio.to_thread.run_sync(
+            lambda: _embed_query_sync(client, query_text)
+        )
+
+    # ------------------------------------------------------------------
+    # 2. Retrieve top-5 chunks scoped to notebook
+    # ------------------------------------------------------------------
+    async def _retrieve_chunks(
+        self,
+        notebook_id: str,
+        query_embedding: list[float],
+    ) -> list[dict]:
+        cypher = """
+            CALL db.index.vector.queryNodes($index, $top_k, $embedding)
+            YIELD node AS chunk, score
+            MATCH (nb:Notebook {id: $notebook_id})
+                  -[:CONTAINS]->(d:Document)
+                  -[:HAS_CHUNK]->(chunk)
+            WHERE score >= $floor
+            RETURN chunk.id        AS chunk_id,
+                   chunk.text      AS text,
+                   chunk.source_file AS source_file,
+                   chunk.page_number AS page_number,
+                   chunk.slide_number AS slide_number,
+                   score
+            ORDER BY score DESC
+            LIMIT $limit
+        """
+        async with self._driver.session() as session:
+            result = await session.run(
+                cypher,
+                index=_VECTOR_INDEX,
+                top_k=_RETRIEVAL_TOP_K,
+                embedding=query_embedding,
+                notebook_id=notebook_id,
+                floor=_SIMILARITY_FLOOR,
+                limit=_RESULT_LIMIT,
+            )
+            return await result.data()
+
+    # ------------------------------------------------------------------
+    # 3. Build the context prompt from retrieved chunks
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _build_context(chunks: list[dict]) -> str:
+        parts: list[str] = []
+        for i, chunk in enumerate(chunks, 1):
+            filename = chunk["source_file"] or "unknown"
+            parts.append(f"[Source {i}: {filename}]\n{chunk['text']}")
+        return "\n\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # 4. Build citations list
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _build_citations(chunks: list[dict]) -> list[dict]:
+        return [
+            {
+                "chunk_id": c["chunk_id"],
+                "filename": c["source_file"] or "unknown",
+                "snippet": c["text"][:120],
+            }
+            for c in chunks
+        ]
+
+    # ------------------------------------------------------------------
+    # 5. Stream Gemini LLM tokens from a background thread
+    # ------------------------------------------------------------------
+    @staticmethod
+    async def _stream_llm(
+        client: genai.Client, prompt: str
+    ) -> AsyncGenerator[str, None]:
+        """Yield text deltas from Gemini streaming, running the sync
+        iterator in a daemon thread and bridging via asyncio.Queue."""
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+
+        def _produce() -> None:
+            try:
+                response = client.models.generate_content_stream(
+                    model=settings.gemini_model,
+                    contents=prompt,
+                )
+                for chunk in response:
+                    if chunk.text:
+                        loop.call_soon_threadsafe(queue.put_nowait, chunk.text)
+            except Exception as exc:            # noqa: BLE001
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, None)
+
+        threading.Thread(target=_produce, daemon=True).start()
+
+        while True:
+            item = await queue.get()
+            if item is None:
+                break
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    # ------------------------------------------------------------------
+    # Public API — non-streaming (kept for backwards compat with query router)
+    # ------------------------------------------------------------------
     async def query(self, notebook_id: str, query_text: str) -> dict:
+        query_embedding = await self._embed_query(query_text)
+        chunks = await self._retrieve_chunks(notebook_id, query_embedding)
+
+        if not chunks:
+            return {
+                "answer": (
+                    "No documents have been uploaded to this notebook yet, "
+                    "or no relevant content was found for your query."
+                ),
+                "sources": [],
+            }
+
+        context = self._build_context(chunks)
+        prompt = (
+            f"{_SYSTEM_INSTRUCTION}\n\nContext:\n{context}\n\n"
+            f"Question: {query_text}"
+        )
+
+        client = _get_genai_client()
+        response = await anyio.to_thread.run_sync(
+            lambda: client.models.generate_content(
+                model=settings.gemini_model,
+                contents=prompt,
+            )
+        )
         return {
-            "answer": "RAG service pending ML implementation",
-            "sources": [],
+            "answer": response.text,
+            "sources": [c["source_file"] or "unknown" for c in chunks],
         }
+
+    # ------------------------------------------------------------------
+    # Public API — SSE streaming with citations
+    # ------------------------------------------------------------------
+    async def stream_chat(
+        self,
+        notebook_id: str,
+        query_text: str,
+    ) -> AsyncGenerator[str, None]:
+        """Yield SSE-formatted events:
+          data: {"token": "..."}
+          data: {"done": true, "citations": [...], "low_confidence": ...}
+        """
+        # 1. Embed the query
+        try:
+            query_embedding = await self._embed_query(query_text)
+        except Exception as exc:
+            logger.exception("Failed to embed query")
+            yield _sse({"token": f"Error: could not process query — {exc}"})
+            yield _sse({"done": True, "citations": [], "low_confidence": True})
+            return
+
+        # 2. Retrieve chunks
+        chunks = await self._retrieve_chunks(notebook_id, query_embedding)
+
+        # 3. No chunks → graceful message
+        if not chunks:
+            yield _sse({
+                "token": (
+                    "No documents have been uploaded to this notebook yet, "
+                    "or no relevant content was found for your query."
+                ),
+            })
+            yield _sse({"done": True, "citations": [], "low_confidence": True})
+            return
+
+        # 4. Confidence check
+        confident = sum(1 for c in chunks if c["score"] >= _CONFIDENCE_THRESHOLD)
+        low_confidence = confident < _MIN_CONFIDENT_CHUNKS
+
+        # 5. Build prompt and citations
+        context = self._build_context(chunks)
+        prompt = (
+            f"{_SYSTEM_INSTRUCTION}\n\nContext:\n{context}\n\n"
+            f"Question: {query_text}"
+        )
+        citations = self._build_citations(chunks)
+
+        # 6. Stream LLM tokens
+        client = _get_genai_client()
+        try:
+            async for token in self._stream_llm(client, prompt):
+                yield _sse({"token": token})
+        except Exception as exc:
+            logger.exception("Gemini LLM streaming error")
+            yield _sse({"token": f"\n\n[Error: {exc}]"})
+
+        # 7. Final event
+        yield _sse({
+            "done": True,
+            "citations": citations,
+            "low_confidence": low_confidence,
+        })
+
+
+def _sse(payload: dict) -> str:
+    """Format a dict as an SSE data line."""
+    return f"data: {json.dumps(payload)}\n\n"

--- a/backend/src/services/rag/graph_rag_service.py
+++ b/backend/src/services/rag/graph_rag_service.py
@@ -17,9 +17,10 @@ from src.lib.config.settings import settings
 from src.services.ingestion.ingestion_service import (
     EMBEDDING_DIMENSIONS,
     EMBEDDING_MODEL,
-    _EMBED_BACKOFF_BASE,
-    _EMBED_MAX_RETRIES,
 )
+
+_EMBED_MAX_RETRIES = 3
+_EMBED_BACKOFF_BASE = 1.0
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +230,7 @@ class GraphRAGService:
             query_embedding = await self._embed_query(query_text)
         except Exception as exc:
             logger.exception("Failed to embed query")
-            yield _sse({"token": f"Error: could not process query — {exc}"})
+            yield _sse({"token": "Sorry, something went wrong processing your query. Please try again."})
             yield _sse({"done": True, "citations": [], "low_confidence": True})
             return
 
@@ -266,7 +267,7 @@ class GraphRAGService:
                 yield _sse({"token": token})
         except Exception as exc:
             logger.exception("Gemini LLM streaming error")
-            yield _sse({"token": f"\n\n[Error: {exc}]"})
+            yield _sse({"token": "\n\nSorry, an error occurred while generating the answer. Please try again."})
 
         # 7. Final event
         yield _sse({

--- a/backend/src/services/rag/graph_rag_service.py
+++ b/backend/src/services/rag/graph_rag_service.py
@@ -185,9 +185,15 @@ class GraphRAGService:
         client: genai.Client, prompt: str
     ) -> AsyncGenerator[str, None]:
         """Yield text deltas from Gemini streaming, running the sync
-        iterator in a daemon thread and bridging via asyncio.Queue."""
+        iterator in a daemon thread and bridging via asyncio.Queue.
+
+        A threading.Event (stop_flag) is checked by the producer so that
+        if the client disconnects and the async generator is cancelled,
+        the background thread stops consuming LLM tokens promptly.
+        """
         loop = asyncio.get_running_loop()
-        queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+        queue: asyncio.Queue[str | Exception | None] = asyncio.Queue(maxsize=64)
+        stop_flag = threading.Event()
 
         def _produce() -> None:
             try:
@@ -196,22 +202,28 @@ class GraphRAGService:
                     contents=prompt,
                 )
                 for chunk in response:
+                    if stop_flag.is_set():
+                        break
                     if chunk.text:
                         loop.call_soon_threadsafe(queue.put_nowait, chunk.text)
             except Exception as exc:            # noqa: BLE001
-                loop.call_soon_threadsafe(queue.put_nowait, exc)
+                if not stop_flag.is_set():
+                    loop.call_soon_threadsafe(queue.put_nowait, exc)
             finally:
                 loop.call_soon_threadsafe(queue.put_nowait, None)
 
         threading.Thread(target=_produce, daemon=True).start()
 
-        while True:
-            item = await queue.get()
-            if item is None:
-                break
-            if isinstance(item, Exception):
-                raise item
-            yield item
+        try:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    break
+                if isinstance(item, Exception):
+                    raise item
+                yield item
+        finally:
+            stop_flag.set()
 
     # ------------------------------------------------------------------
     # Public API — non-streaming (kept for backwards compat with query router)

--- a/backend/src/services/rag/graph_rag_service.py
+++ b/backend/src/services/rag/graph_rag_service.py
@@ -24,7 +24,8 @@ _EMBED_BACKOFF_BASE = 1.0
 
 logger = logging.getLogger(__name__)
 
-_VECTOR_INDEX = "chunk_embeddings"
+_CONTENT_VECTOR_INDEX = "chunk_embeddings"
+_NOTE_VECTOR_INDEX = "note_chunk_embeddings"
 _RETRIEVAL_TOP_K = 20  # cast a wide net, then filter by notebook
 _RESULT_LIMIT = 5
 _SIMILARITY_FLOOR = 0.50  # minimum to include a chunk at all
@@ -83,40 +84,71 @@ class GraphRAGService:
         )
 
     # ------------------------------------------------------------------
-    # 2. Retrieve top-5 chunks scoped to notebook
+    # 2. Retrieve top-5 chunks scoped to notebook (documents + notes)
     # ------------------------------------------------------------------
     async def _retrieve_chunks(
         self,
         notebook_id: str,
         query_embedding: list[float],
     ) -> list[dict]:
-        cypher = """
+        content_cypher = """
             CALL db.index.vector.queryNodes($index, $top_k, $embedding)
             YIELD node AS chunk, score
             MATCH (nb:Notebook {id: $notebook_id})
                   -[:CONTAINS]->(d:Document)
                   -[:HAS_CHUNK]->(chunk)
             WHERE score >= $floor
-            RETURN chunk.id        AS chunk_id,
-                   chunk.text      AS text,
+            RETURN chunk.id          AS chunk_id,
+                   chunk.text        AS text,
                    chunk.source_file AS source_file,
                    chunk.page_number AS page_number,
                    chunk.slide_number AS slide_number,
+                   'document'        AS source_type,
                    score
             ORDER BY score DESC
             LIMIT $limit
         """
+        note_cypher = """
+            CALL db.index.vector.queryNodes($index, $top_k, $embedding)
+            YIELD node AS chunk, score
+            MATCH (nb:Notebook {id: $notebook_id})
+                  -[:HAS_NOTE]->(n:Note)
+                  -[:HAS_CHUNK]->(chunk)
+            WHERE score >= $floor
+            RETURN chunk.id         AS chunk_id,
+                   chunk.text       AS text,
+                   chunk.note_title AS source_file,
+                   null             AS page_number,
+                   null             AS slide_number,
+                   'note'           AS source_type,
+                   score
+            ORDER BY score DESC
+            LIMIT $limit
+        """
+        params = dict(
+            top_k=_RETRIEVAL_TOP_K,
+            embedding=query_embedding,
+            notebook_id=notebook_id,
+            floor=_SIMILARITY_FLOOR,
+            limit=_RESULT_LIMIT,
+        )
         async with self._driver.session() as session:
-            result = await session.run(
-                cypher,
-                index=_VECTOR_INDEX,
-                top_k=_RETRIEVAL_TOP_K,
-                embedding=query_embedding,
-                notebook_id=notebook_id,
-                floor=_SIMILARITY_FLOOR,
-                limit=_RESULT_LIMIT,
+            content_result = await session.run(
+                content_cypher, index=_CONTENT_VECTOR_INDEX, **params,
             )
-            return await result.data()
+            content_chunks = await content_result.data()
+
+            note_result = await session.run(
+                note_cypher, index=_NOTE_VECTOR_INDEX, **params,
+            )
+            note_chunks = await note_result.data()
+
+        merged = sorted(
+            content_chunks + note_chunks,
+            key=lambda c: c["score"],
+            reverse=True,
+        )
+        return merged[:_RESULT_LIMIT]
 
     # ------------------------------------------------------------------
     # 3. Build the context prompt from retrieved chunks
@@ -125,8 +157,9 @@ class GraphRAGService:
     def _build_context(chunks: list[dict]) -> str:
         parts: list[str] = []
         for i, chunk in enumerate(chunks, 1):
-            filename = chunk["source_file"] or "unknown"
-            parts.append(f"[Source {i}: {filename}]\n{chunk['text']}")
+            name = chunk["source_file"] or "unknown"
+            label = "Note" if chunk.get("source_type") == "note" else "Document"
+            parts.append(f"[Source {i} ({label}): {name}]\n{chunk['text']}")
         return "\n\n".join(parts)
 
     # ------------------------------------------------------------------
@@ -139,6 +172,7 @@ class GraphRAGService:
                 "chunk_id": c["chunk_id"],
                 "filename": c["source_file"] or "unknown",
                 "snippet": c["text"][:120],
+                "source_type": c.get("source_type", "document"),
             }
             for c in chunks
         ]

--- a/backend/src/services/rag/graph_rag_service.py
+++ b/backend/src/services/rag/graph_rag_service.py
@@ -5,7 +5,9 @@ RAG chat service: embed query -> retrieve chunks -> stream LLM answer with citat
 import asyncio
 import json
 import logging
+import re
 import threading
+import time
 from typing import AsyncGenerator
 
 import anyio
@@ -26,7 +28,10 @@ logger = logging.getLogger(__name__)
 
 _CONTENT_VECTOR_INDEX = "chunk_embeddings"
 _NOTE_VECTOR_INDEX = "note_chunk_embeddings"
-_RETRIEVAL_TOP_K = 20  # cast a wide net, then filter by notebook
+# Cast a wide net so that notebook-scoped chunks are included even in a large
+# multi-tenant index.  At 200 candidates the per-request overhead is small
+# (Neo4j traverses the HNSW graph) while making false-zero results rare.
+_RETRIEVAL_TOP_K = 200
 _RESULT_LIMIT = 5
 _SIMILARITY_FLOOR = 0.50  # minimum to include a chunk at all
 _CONFIDENCE_THRESHOLD = 0.75  # for the low_confidence flag
@@ -36,7 +41,9 @@ _SYSTEM_INSTRUCTION = (
     "You are a helpful study assistant. Answer the user's question based ONLY "
     "on the provided context from their notebook documents. If the context "
     "doesn't contain enough information to answer the question, say so clearly. "
-    "Be concise and accurate."
+    "Be concise and accurate. "
+    "When you use information from a source, cite it inline using [Source N] "
+    "where N matches the source number in the context provided."
 )
 
 
@@ -51,8 +58,6 @@ def _get_genai_client() -> genai.Client:
 
 def _embed_query_sync(client: genai.Client, text: str) -> list[float]:
     """Embed a single query string (blocking). Retries on transient errors."""
-    import time
-
     for attempt in range(_EMBED_MAX_RETRIES):
         try:
             response = client.models.embed_content(
@@ -163,7 +168,7 @@ class GraphRAGService:
         return "\n\n".join(parts)
 
     # ------------------------------------------------------------------
-    # 4. Build citations list
+    # 4. Build citations list (all retrieved chunks)
     # ------------------------------------------------------------------
     @staticmethod
     def _build_citations(chunks: list[dict]) -> list[dict]:
@@ -176,6 +181,29 @@ class GraphRAGService:
             }
             for c in chunks
         ]
+
+    # ------------------------------------------------------------------
+    # 4b. Filter citations to only chunks actually cited in the answer
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _extract_cited_citations(chunks: list[dict], answer: str) -> list[dict]:
+        """Return citations only for [Source N] markers present in *answer*.
+
+        Falls back to all chunks if the model emitted no markers.
+        """
+        referenced = {int(m) for m in re.findall(r"\[Source\s+(\d+)\]", answer)}
+        cited = [
+            {
+                "chunk_id": chunks[i - 1]["chunk_id"],
+                "filename": chunks[i - 1]["source_file"] or "unknown",
+                "snippet": chunks[i - 1]["text"][:120],
+                "source_type": chunks[i - 1].get("source_type", "document"),
+            }
+            for i in sorted(referenced)
+            if 1 <= i <= len(chunks)
+        ]
+        # Fallback: include all chunks when the model produced no inline markers
+        return cited if cited else GraphRAGService._build_citations(chunks)
 
     # ------------------------------------------------------------------
     # 5. Stream Gemini LLM tokens from a background thread
@@ -229,7 +257,21 @@ class GraphRAGService:
     # Public API — non-streaming (kept for backwards compat with query router)
     # ------------------------------------------------------------------
     async def query(self, notebook_id: str, query_text: str) -> dict:
-        query_embedding = await self._embed_query(query_text)
+        try:
+            query_embedding = await self._embed_query(query_text)
+        except EnvironmentError:
+            logger.exception("GEMINI_API_KEY not configured")
+            return {
+                "answer": "The AI assistant is not configured. Please contact your administrator.",
+                "sources": [],
+            }
+        except Exception:
+            logger.exception("Failed to embed query in query()")
+            return {
+                "answer": "Sorry, something went wrong processing your query. Please try again.",
+                "sources": [],
+            }
+
         chunks = await self._retrieve_chunks(notebook_id, query_embedding)
 
         if not chunks:
@@ -248,12 +290,19 @@ class GraphRAGService:
         )
 
         client = _get_genai_client()
-        response = await anyio.to_thread.run_sync(
-            lambda: client.models.generate_content(
-                model=settings.gemini_model,
-                contents=prompt,
+        try:
+            response = await anyio.to_thread.run_sync(
+                lambda: client.models.generate_content(
+                    model=settings.gemini_model,
+                    contents=prompt,
+                )
             )
-        )
+        except Exception:
+            logger.exception("LLM generate_content failed in query()")
+            return {
+                "answer": "Sorry, the AI assistant is temporarily unavailable. Please try again later.",
+                "sources": [],
+            }
         return {
             "answer": response.text,
             "sources": [c["source_file"] or "unknown" for c in chunks],
@@ -274,7 +323,7 @@ class GraphRAGService:
         # 1. Embed the query
         try:
             query_embedding = await self._embed_query(query_text)
-        except Exception as exc:
+        except Exception:
             logger.exception("Failed to embed query")
             yield _sse({"token": "Sorry, something went wrong processing your query. Please try again."})
             yield _sse({"done": True, "citations": [], "low_confidence": True})
@@ -298,27 +347,32 @@ class GraphRAGService:
         confident = sum(1 for c in chunks if c["score"] >= _CONFIDENCE_THRESHOLD)
         low_confidence = confident < _MIN_CONFIDENT_CHUNKS
 
-        # 5. Build prompt and citations
+        # 5. Build prompt
         context = self._build_context(chunks)
         prompt = (
             f"{_SYSTEM_INSTRUCTION}\n\nContext:\n{context}\n\n"
             f"Question: {query_text}"
         )
-        citations = self._build_citations(chunks)
 
-        # 6. Stream LLM tokens
+        # 6. Stream LLM tokens; accumulate full answer to extract inline citations
         client = _get_genai_client()
+        answer_parts: list[str] = []
         try:
             async for token in self._stream_llm(client, prompt):
+                answer_parts.append(token)
                 yield _sse({"token": token})
-        except Exception as exc:
+        except Exception:
             logger.exception("Gemini LLM streaming error")
             yield _sse({"token": "\n\nSorry, an error occurred while generating the answer. Please try again."})
 
-        # 7. Final event
+        # 7. Derive citations from [Source N] markers actually used in the answer
+        full_answer = "".join(answer_parts)
+        cited = self._extract_cited_citations(chunks, full_answer)
+
+        # 8. Final event
         yield _sse({
             "done": True,
-            "citations": citations,
+            "citations": cited,
             "low_confidence": low_confidence,
         })
 

--- a/backend/tests/api/test_chat.py
+++ b/backend/tests/api/test_chat.py
@@ -1,0 +1,219 @@
+"""
+API tests for POST /api/v1/notebooks/{notebook_id}/chat.
+
+Uses dependency overrides and monkeypatching (same pattern as test_notes.py)
+so no real Neo4j or Gemini calls are made.
+"""
+import json
+from datetime import datetime, timezone
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from src.api.main import app
+from src.api.routers.chat import get_rag_service
+from src.lib.auth.jwt import get_current_user
+from src.lib.db.neo4j import get_driver
+
+BASE_URL = "http://testserver"
+CHAT_URL = "/api/v1/notebooks/{notebook_id}/chat"
+
+OWNER_ID = "user-abc"
+OTHER_USER_ID = "user-xyz"
+NOTEBOOK_ID = "nb-001"
+
+_NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+_NOTEBOOK = {
+    "id": NOTEBOOK_ID,
+    "title": "Physics",
+    "course_code": "PHYS101",
+    "description": "",
+    "owner_id": OWNER_ID,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rag_service_with_stream(events: list[str]):
+    """Return a mock GraphRAGService whose stream_chat yields the given events."""
+
+    async def _stream(notebook_id: str, query_text: str) -> AsyncGenerator[str, None]:
+        for event in events:
+            yield event
+
+    svc = MagicMock()
+    svc.stream_chat = _stream
+    return svc
+
+
+def _token_event(text: str) -> str:
+    return f"data: {json.dumps({'token': text})}\n\n"
+
+
+def _done_event(citations=None, low_confidence=False) -> str:
+    return f"data: {json.dumps({'done': True, 'citations': citations or [], 'low_confidence': low_confidence})}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=BASE_URL) as c:
+        yield c
+
+
+@pytest.fixture
+def override_deps(monkeypatch):
+    """Patch NotebookRepository as imported in the chat router and provide
+    control over the RAG service via dependency overrides."""
+
+    def _setup(notebook=_NOTEBOOK, current_user=OWNER_ID, rag_events=None):
+        # Patch NotebookRepository as seen by the chat router
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.get_by_id = AsyncMock(return_value=notebook)
+        monkeypatch.setattr(
+            "src.api.routers.chat.NotebookRepository",
+            lambda _driver: mock_repo_instance,
+        )
+
+        # Override auth
+        app.dependency_overrides[get_current_user] = lambda: current_user
+
+        # Override driver (so no real Neo4j connection is attempted)
+        app.dependency_overrides[get_driver] = lambda: MagicMock()
+
+        # Override RAG service
+        if rag_events is not None:
+            svc = _rag_service_with_stream(rag_events)
+            app.dependency_overrides[get_rag_service] = lambda: svc
+
+    return _setup
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_overrides():
+    yield
+    for dep in (get_current_user, get_rag_service, get_driver):
+        app.dependency_overrides.pop(dep, None)
+
+
+# ---------------------------------------------------------------------------
+# Auth tests
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_no_auth_returns_401(client):
+    resp = await client.post(
+        CHAT_URL.format(notebook_id=NOTEBOOK_ID),
+        json={"query": "hello"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_chat_not_found_notebook_returns_404(client, override_deps):
+    override_deps(notebook=None)
+    resp = await client.post(
+        CHAT_URL.format(notebook_id="nonexistent"),
+        json={"query": "hello"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_chat_other_owner_returns_404(client, override_deps):
+    """Notebook exists but belongs to a different user → 404 (no existence leak)."""
+    override_deps(notebook=_NOTEBOOK, current_user=OTHER_USER_ID)
+    resp = await client.post(
+        CHAT_URL.format(notebook_id=NOTEBOOK_ID),
+        json={"query": "hello"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming tests
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_streams_token_events(client, override_deps):
+    events = [
+        _token_event("Hello"),
+        _token_event(" world"),
+        _done_event(citations=[], low_confidence=False),
+    ]
+    override_deps(rag_events=events)
+
+    resp = await client.post(
+        CHAT_URL.format(notebook_id=NOTEBOOK_ID),
+        json={"query": "What is this?"},
+    )
+
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+    body = resp.text
+    assert 'data: {"token": "Hello"}' in body
+    assert 'data: {"token": " world"}' in body
+    assert '"done": true' in body
+
+
+async def test_chat_final_event_contains_citations(client, override_deps):
+    citation = {"chunk_id": "c1", "filename": "notes.pdf", "snippet": "...", "source_type": "document"}
+    events = [
+        _token_event("Answer [Source 1]"),
+        _done_event(citations=[citation], low_confidence=False),
+    ]
+    override_deps(rag_events=events)
+
+    resp = await client.post(
+        CHAT_URL.format(notebook_id=NOTEBOOK_ID),
+        json={"query": "Explain?"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.text
+    done_lines = [
+        line[len("data: "):] for line in body.splitlines() if line.startswith("data: ")
+    ]
+    done_payload = next(
+        (json.loads(p) for p in done_lines if json.loads(p).get("done")),
+        None,
+    )
+    assert done_payload is not None
+    assert done_payload["done"] is True
+    assert done_payload["citations"] == [citation]
+    assert done_payload["low_confidence"] is False
+
+
+async def test_chat_low_confidence_flag(client, override_deps):
+    events = [
+        _token_event("Uncertain answer"),
+        _done_event(citations=[], low_confidence=True),
+    ]
+    override_deps(rag_events=events)
+
+    resp = await client.post(
+        CHAT_URL.format(notebook_id=NOTEBOOK_ID),
+        json={"query": "Obscure question"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.text
+    done_lines = [
+        json.loads(line[len("data: "):])
+        for line in body.splitlines()
+        if line.startswith("data: ")
+    ]
+    done_payload = next((p for p in done_lines if p.get("done")), None)
+    assert done_payload is not None
+    assert done_payload["low_confidence"] is True
+


### PR DESCRIPTION
## Summary
- Implement POST /api/v1/notebooks/{notebook_id}/chat with SSE streaming
- Replace stub GraphRAGService with full RAG pipeline: embed query via Gemini, retrieve top-5 chunks from Neo4j vector index, stream LLM answer with citations
- Add chat router, request/response schemas, and gemini_model config setting
- Include low_confidence flag when fewer than 2 chunks score above 0.75
- Increase `_RETRIEVAL_TOP_K` from 20 to 200 to ensure notebook-scoped chunks are found reliably in multi-tenant deployments
- Citations in the final SSE event now reflect only chunks actually referenced by the LLM via `[Source N]` inline markers (falls back to all retrieved chunks when no markers are emitted)
- `query()` and embedding failures return user-safe error messages instead of propagating as 500 errors
- README curl example uses `$TOKEN`/`$NOTEBOOK_ID` placeholders in a fenced code block (no credential leakage)
- API tests added for the chat endpoint covering auth (401/404) and SSE event structure