### PR TITLE
Implement focus mode with widget and icon updates

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -20,7 +20,7 @@ async def neo4j_driver(neo4j_container):
 
     driver = AsyncGraphDatabase.driver(
         neo4j_container.get_connection_url(),
-        auth=("neo4j", "password"),
+        auth=(neo4j_container.username, neo4j_container.password),
     )
     await startup.__wrapped__(driver) if hasattr(startup, "__wrapped__") else await _run_startup(driver)
     yield driver

--- a/frontend/src/app/backpack/[id]/notes/page.tsx
+++ b/frontend/src/app/backpack/[id]/notes/page.tsx
@@ -15,6 +15,9 @@ import DocumentViewer from '../../../../components/DocumentViewer';
 import { useNotes, useCreateNote, useUpdateNote, useDeleteNote } from '../../../../hooks/useNotes';
 import { useDocuments, usePatchDocument } from '../../../../hooks/useDocuments';
 import { uploadFile, type NoteResponse, type DocumentResponse } from '../../../../lib/api';
+import DraggableFloatingWidget from '../../../../components/study/DraggableFloatingWidget';
+import StudyToolsPanel from '../../../../components/study/StudyToolsPanel';
+import { useUiStore } from '../../../../lib/store/ui';
 
 // ---------------------------------------------------------------------------
 // buildFileTree — trie-based from folder_path strings
@@ -138,6 +141,7 @@ function buildFileTree(
 
 export default function NotesForNotebookPage() {
   const { id } = useParams<{ id: string }>();
+  const isFocusMode = useUiStore((s) => s.isFocusMode);
 
   const [leftPaneOpen, setLeftPaneOpen] = useState(true);
   const [rightPaneOpen, setRightPaneOpen] = useState(true);
@@ -335,12 +339,24 @@ export default function NotesForNotebookPage() {
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,rgba(220,230,225,0.4)_0%,transparent_60%)]" />
       </div>
 
-      <main className="relative z-10 h-full overflow-hidden">
-        <div className="mx-auto max-w-full flex flex-row flex-1 pt-16 h-full gap-2 px-2">
+      <main className="relative z-10 flex h-full min-h-0 flex-col overflow-hidden">
+        <DraggableFloatingWidget
+          storageKey={id ? `notebud-pomodoro-pos-${id}` : 'notebud-pomodoro-pos'}
+          defaultTop={isFocusMode ? 64 : 72}
+        >
+          <StudyToolsPanel
+            storageKeyExpanded={id ? `notebud-study-panel-open-${id}` : 'notebud-study-panel-open'}
+          />
+        </DraggableFloatingWidget>
+        <div
+          className={`mx-auto flex min-h-0 w-full max-w-full flex-1 flex-row gap-2 px-2 ${
+            isFocusMode ? 'pt-0' : 'pt-16'
+          }`}
+        >
 
           {/* File tree pane (collapsible) */}
           <aside
-            className={`overflow-hidden transition-[flex-basis] duration-200 flex-shrink-0 min-w-0 ${
+            className={`min-h-0 h-full overflow-hidden transition-[flex-basis] duration-200 flex-shrink-0 min-w-0 ${
               leftPaneOpen ? 'flex-[0_0_17%]' : 'flex-[0_0_0%]'
             }`}
           >
@@ -451,7 +467,7 @@ export default function NotesForNotebookPage() {
           />
 
           {/* Notes pane (center) */}
-          <section className="relative h-full flex-1 min-w-0 overflow-hidden flex flex-col">
+          <section className="relative flex min-h-0 h-full min-w-0 flex-1 flex-col overflow-hidden">
             <div className="glass-panel flex flex-col backdrop-blur-[30px] border border-white/30 flex-1 min-h-0 h-full overflow-hidden">
               <NotesTabs
                 tabs={tabs}
@@ -535,7 +551,7 @@ export default function NotesForNotebookPage() {
 
           {/* Chat pane (right) */}
           <aside
-            className={`overflow-hidden transition-[flex-basis] duration-200 flex-shrink-0 min-w-0 ${
+            className={`min-h-0 h-full overflow-hidden transition-[flex-basis] duration-200 flex-shrink-0 min-w-0 ${
               rightPaneOpen ? 'flex-[0_0_25%]' : 'flex-[0_0_0%]'
             }`}
           >

--- a/frontend/src/app/backpack/[id]/notes/page.tsx
+++ b/frontend/src/app/backpack/[id]/notes/page.tsx
@@ -142,6 +142,7 @@ function buildFileTree(
 export default function NotesForNotebookPage() {
   const { id } = useParams<{ id: string }>();
   const isFocusMode = useUiStore((s) => s.isFocusMode);
+  const setIsFocusMode = useUiStore((s) => s.setIsFocusMode);
 
   const [leftPaneOpen, setLeftPaneOpen] = useState(true);
   const [rightPaneOpen, setRightPaneOpen] = useState(true);
@@ -340,14 +341,17 @@ export default function NotesForNotebookPage() {
       </div>
 
       <main className="relative z-10 flex h-full min-h-0 flex-col overflow-hidden">
-        <DraggableFloatingWidget
-          storageKey={id ? `notebud-pomodoro-pos-${id}` : 'notebud-pomodoro-pos'}
-          defaultTop={isFocusMode ? 64 : 72}
-        >
-          <StudyToolsPanel
-            storageKeyExpanded={id ? `notebud-study-panel-open-${id}` : 'notebud-study-panel-open'}
-          />
-        </DraggableFloatingWidget>
+        {isFocusMode ? (
+          <DraggableFloatingWidget
+            storageKey={id ? `notebud-pomodoro-pos-${id}` : 'notebud-pomodoro-pos'}
+            defaultTop={64}
+            onClose={() => setIsFocusMode(false)}
+          >
+            <StudyToolsPanel
+              storageKeyExpanded={id ? `notebud-study-panel-open-${id}` : 'notebud-study-panel-open'}
+            />
+          </DraggableFloatingWidget>
+        ) : null}
         <div
           className={`mx-auto flex min-h-0 w-full max-w-full flex-1 flex-row gap-2 px-2 ${
             isFocusMode ? 'pt-0' : 'pt-16'

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react'
-import { Bars3Icon, XMarkIcon, BookOpenIcon } from '@heroicons/react/24/outline'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '../lib/store/auth'
 import { abortAllInFlightRequests, disableAuthHeadersFor } from '../lib/api/client'
@@ -13,190 +13,260 @@ import { useQuery } from '@tanstack/react-query'
 import { ChevronRightIcon } from '@heroicons/react/24/outline'
 import SettingsDropdown from './SettingsDropdown'
 import { useAvatarUrl } from '../hooks/useAvatar'
+import BackpackIcon from "./icons/BackpackIcon"
+import FocusToggle from './study/FocusToggle'
+import PomodoroIcon from './icons/PomodoroIcon'
+import { useUiStore } from '../lib/store/ui'
 
 const navLinks = [
-  { href: '/backpack', label: 'Backpack', Icon: BookOpenIcon, protected: true },
+    { href: '/backpack', label: 'Backpack', Icon: BackpackIcon, protected: true },
 ];
 
+type NavBarPanelProps = {
+    token: string | null | undefined;
+    pathname: string;
+    isFocusMode: boolean;
+    displayInitial: string;
+    username: string | null | undefined;
+    handleLogout: () => void;
+};
+
+function NavMenuPanel({ token, pathname, isFocusMode, displayInitial, username, handleLogout }: NavBarPanelProps) {
+    return (
+        <>
+            <div className="space-y-1 pt-2 pb-3">
+                {token ? (
+                    <DisclosureButton
+                        as={FocusToggle}
+                        label="Focus mode"
+                        className={`w-full justify-start border-l-4 py-2 pr-4 pl-3 text-base font-medium ${
+                            isFocusMode
+                                ? 'border-emerald-600 bg-emerald-50 text-emerald-700'
+                                : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
+                        }`}
+                    />
+                ) : (
+                    <DisclosureButton
+                        as={Link}
+                        href="/login"
+                        className="hover:cursor-pointer flex items-center gap-2 border-l-4 border-transparent py-2 pr-4 pl-3 text-base font-medium text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800"
+                    >
+                        <PomodoroIcon className="shrink-0" />
+                        Focus mode
+                    </DisclosureButton>
+                )}
+                {navLinks.map(({ href, label, protected: isProtected }) => {
+                    const linkPath = href.split('?')[0]
+                    const isActive = href !== '#' && pathname === linkPath
+                    const activeClass = 'border-emerald-600 bg-emerald-50 text-emerald-700'
+                    const defaultClass = 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
+                    const baseClass = `block cursor-pointer border-l-4 py-2 pr-4 pl-3 text-base font-medium ${isActive ? activeClass : defaultClass}`
+                    const resolvedHref = isProtected && !token ? '/login' : href
+                    return (
+                        <DisclosureButton key={label} as={Link} href={resolvedHref} className={baseClass}>
+                            {label}
+                        </DisclosureButton>
+                    )
+                })}
+            </div>
+            <div className="border-t border-gray-200 pt-4 pb-3">
+                {token ? (
+                    <>
+                        <div className="flex items-center px-4">
+                            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-sm font-medium text-white outline -outline-offset-1 outline-black/10">
+                                {displayInitial}
+                            </div>
+                            <div className="ml-3 min-w-0">
+                                <div className="truncate text-base font-medium text-gray-800">
+                                    {username || 'Signed in'}
+                                </div>
+                                <div className="text-sm font-medium text-gray-500">NoteBud account</div>
+                            </div>
+                        </div>
+                        <div className="mt-3 space-y-1 px-2">
+                            <DisclosureButton
+                                type="button"
+                                onClick={handleLogout}
+                                className="block w-full cursor-pointer rounded-md px-4 py-2 text-left text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800"
+                            >
+                                Sign out
+                            </DisclosureButton>
+                        </div>
+                    </>
+                ) : (
+                    <div className="space-y-2 px-4">
+                        <DisclosureButton
+                            as={Link}
+                            href="/login"
+                            className="block w-full cursor-pointer rounded-md border border-gray-200 px-4 py-2 text-center text-base font-medium text-gray-800 hover:bg-gray-50"
+                        >
+                            Sign in
+                        </DisclosureButton>
+                        <DisclosureButton
+                            as={Link}
+                            href="/register"
+                            className="block w-full cursor-pointer rounded-md bg-emerald-600 px-4 py-2 text-center text-base font-medium text-white hover:bg-emerald-700"
+                        >
+                            Register
+                        </DisclosureButton>
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}
+
 export default function NavBar() {
-  const pathname = usePathname();
-  const token = useAuthStore((s) => s.token);
-  const username = useAuthStore((s) => s.username);
-  const clearSession = useAuthStore((s) => s.clearSession);
-  const queryClient = useQueryClient();
+    const pathname = usePathname();
+    const token = useAuthStore((s) => s.token);
+    const username = useAuthStore((s) => s.username);
+    const clearSession = useAuthStore((s) => s.clearSession);
+    const queryClient = useQueryClient();
 
-  const handleLogout = () => {
-    queryClient.cancelQueries();
-    queryClient.clear();
-    abortAllInFlightRequests();
-    clearSession();
-    disableAuthHeadersFor(10000);
-    window.location.assign('/login');
-  };
+    const handleLogout = () => {
+        queryClient.cancelQueries();
+        queryClient.clear();
+        abortAllInFlightRequests();
+        clearSession();
+        disableAuthHeadersFor(10000);
+        window.location.assign('/login');
+    };
 
-  const displayInitial = username?.trim()?.charAt(0).toUpperCase() || '?';
-  const { blobUrl: avatarUrl } = useAvatarUrl();
+    const displayInitial = username?.trim()?.charAt(0).toUpperCase() || '?';
+    const { blobUrl: avatarUrl } = useAvatarUrl();
 
-  // Extract notebook ID from /backpack/[id]/... routes
-  const notebookIdMatch = pathname.match(/^\/backpack\/([^/]+)/);
-  const notebookId = notebookIdMatch?.[1];
+    const notebookIdMatch = pathname.match(/^\/backpack\/([^/]+)/);
+    const notebookId = notebookIdMatch?.[1];
 
-  const { data: currentNotebook } = useQuery({
-    queryKey: ['notebook', notebookId],
-    queryFn: () => getNotebook(notebookId!),
-    enabled: !!notebookId && !!token,
-    staleTime: 60 * 1000,
-  });
+    const { data: currentNotebook } = useQuery({
+        queryKey: ['notebook', notebookId],
+        queryFn: () => getNotebook(notebookId!),
+        enabled: !!notebookId && !!token,
+        staleTime: 60 * 1000,
+    });
 
-  return (
-    <Disclosure as="nav" className="relative z-20 glass-panel backdrop-blur-[30px]">
-      <div className="mx-auto max-w-8xl sm:px-6 lg:px-12">
-        <div className="flex h-16 justify-between">
-          <div className="flex px-4 lg:px-6">
-            <div className="flex shrink-0 items-center">
-              <img
-                alt="NoteBud Logo"
-                src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=emerald&shade=600"
-                className="h-8 w-auto"
-              />
-            </div>
-            <div className="hidden lg:ml-6 lg:flex lg:items-center lg:gap-3">
-              {navLinks.map(({ href, label, Icon, protected: isProtected }, i) => {
-                const linkPath = href.split('?')[0]
-                const isActive = href !== '#' && pathname === linkPath
-                const activeClass = 'border-emerald-600 text-gray-900'
-                const defaultClass = 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                const resolvedHref = isProtected && !token ? '/login' : href
-                return (
-                  <React.Fragment key={label}>
-                    {i > 0 && <span className="text-gray-300 text-2xl select-none">|</span>}
-                    <Link href={resolvedHref} className={`inline-flex items-center gap-1.5 border-b-2 px-1 pt-1 text-2xl font-semibold ${isActive ? activeClass : defaultClass}`}>
-                      <Icon className="h-6 w-6" />
-                      {label}
-                    </Link>
-                  </React.Fragment>
-                )
-              })}
-            </div>
-          </div>
-          {/* Notebook breadcrumb */}
-          {currentNotebook && (
-            <div className="hidden lg:flex items-center gap-1.5 ml-4 text-slate-400">
-              <ChevronRightIcon className="h-4 w-4 flex-shrink-0" />
-              <span className="text-sm font-medium text-slate-600 truncate max-w-[200px]">
-                {currentNotebook.course_code}
-              </span>
-              <span className="text-slate-300">·</span>
-              <span className="text-sm text-slate-500 truncate max-w-[240px]">
-                {currentNotebook.title}
-              </span>
-            </div>
-          )}
+    const isFocusMode = useUiStore((s) => s.isFocusMode);
 
-          <div className="flex items-center lg:hidden">
-            {/* Mobile menu button */}
-            <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-2 focus:-outline-offset-1 focus:outline-emerald-600">
-              <span className="absolute -inset-0.5" />
-              <span className="sr-only">Open navigation menu</span>
-              <Bars3Icon aria-hidden="true" className="block size-6 group-data-open:hidden" />
-              <XMarkIcon aria-hidden="true" className="hidden size-6 group-data-open:block" />
-            </DisclosureButton>
-          </div>
-          <div className="hidden lg:ml-4 lg:flex lg:items-center lg:gap-3">
-            <SettingsDropdown />
+    const panelProps: NavBarPanelProps = {
+        token,
+        pathname,
+        isFocusMode,
+        displayInitial,
+        username,
+        handleLogout,
+    };
 
-            {token ? (
-              <div className="ml-1 flex items-center gap-2">
-                <span className="flex size-8 items-center justify-center rounded-full bg-emerald-600 text-sm font-medium text-white outline -outline-offset-1 outline-black/10 overflow-hidden">
-                  {avatarUrl
-                    ? <img src={avatarUrl} alt="Avatar" className="w-full h-full object-cover" />
-                    : displayInitial
-                  }
-                </span>
-                <span className="max-w-[10rem] truncate text-sm font-medium text-gray-800">
-                  {username || 'Signed in'}
-                </span>
-              </div>
-            ) : (
-              <div className="flex items-center gap-2">
-                <Link
-                  href="/"
-                  className="rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-white/50 hover:text-gray-900"
-                >
-                  Sign in
-                </Link>
-                <Link
-                  href="/register"
-                  className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700"
-                >
-                  Register
-                </Link>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      <DisclosurePanel className="lg:hidden">
-        <div className="space-y-1 pt-2 pb-3">
-          {navLinks.map(({ href, label, protected: isProtected }) => {
-            const linkPath = href.split('?')[0]
-            const isActive = href !== '#' && pathname === linkPath
-            const activeClass = 'border-emerald-600 bg-emerald-50 text-emerald-700'
-            const defaultClass = 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
-            const baseClass = `block border-l-4 py-2 pr-4 pl-3 text-base font-medium ${isActive ? activeClass : defaultClass}`
-            const resolvedHref = isProtected && !token ? '/login' : href
-            return (
-              <DisclosureButton key={label} as={Link} href={resolvedHref} className={baseClass}>
-                {label}
-              </DisclosureButton>
-            )
-          })}
-        </div>
-        <div className="border-t border-gray-200 pt-4 pb-3">
-          {token ? (
-            <>
-              <div className="flex items-center px-4">
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-sm font-medium text-white outline -outline-offset-1 outline-black/10">
-                  {displayInitial}
+    if (isFocusMode) {
+        return (
+            <Disclosure as="nav" className="pointer-events-none fixed left-1/2 -translate-x-1/2 top-3 z-[60] flex flex-col items-center">
+                <div className="pointer-events-auto relative flex flex-col items-start gap-2">
+                    <div className="flex items-start gap-1 rounded-2xl border border-white/50 bg-white/80 px-1.5 py-1 shadow-[0_8px_30px_rgba(0,0,0,0.12)] backdrop-blur-xl">
+                        <DisclosureButton className="group relative inline-flex cursor-pointer items-center justify-center rounded-xl p-2 text-slate-600 transition-colors hover:bg-white/60 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500">
+                            <span className="sr-only">Open navigation menu</span>
+                            <Bars3Icon aria-hidden="true" className="block size-6 group-data-open:hidden" />
+                            <XMarkIcon aria-hidden="true" className="hidden size-6 group-data-open:block" />
+                        </DisclosureButton>
+                        {token ? <FocusToggle /> : null}
+                    </div>
+                    <DisclosurePanel className="absolute center top-[calc(100%+6px)] z-50 max-h-[min(85vh,560px)] w-[min(calc(100vw-1.5rem),20rem)] overflow-y-auto rounded-xl border border-white/40 bg-white/95 shadow-xl backdrop-blur-md outline-none">
+                        <NavMenuPanel {...panelProps} />
+                    </DisclosurePanel>
                 </div>
-                <div className="ml-3 min-w-0">
-                  <div className="truncate text-base font-medium text-gray-800">
-                    {username || 'Signed in'}
-                  </div>
-                  <div className="text-sm font-medium text-gray-500">NoteBud account</div>
+            </Disclosure>
+        );
+    }
+
+    return (
+        <Disclosure as="nav" className="relative z-20 glass-panel backdrop-blur-[30px]">
+            <div className="mx-auto max-w-8xl sm:px-6 lg:px-12">
+                <div className="flex h-16 justify-between">
+                    <div className="flex px-4 lg:px-6">
+                        <div className="flex shrink-0 items-center">
+                            <img
+                                alt="NoteBud Logo"
+                                src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=emerald&shade=600"
+                                className="h-8 w-auto"
+                            />
+                        </div>
+                        <div className="hidden lg:ml-6 lg:flex lg:items-center lg:gap-3 pb-1">
+                            {navLinks.map(({ href, label, Icon, protected: isProtected }, i) => {
+                                const linkPath = href.split('?')[0]
+                                const isActive = href !== '#' && pathname === linkPath
+                                const activeClass = 'border-emerald-600 text-gray-900'
+                                const defaultClass = 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                                const resolvedHref = isProtected && !token ? '/login' : href
+                                return (
+                                    <React.Fragment key={label}>
+                                        {i > 0 && <span className="text-gray-300 text-2xl select-none">|</span>}
+                                        <Link href={resolvedHref} className={`inline-flex cursor-pointer items-center gap-1.5 border-b-2 px-1 pt-1 text-lg font-semibold ${isActive ? activeClass : defaultClass}`}>
+                                            <Icon className="h-4 w-4" />
+                                            {label}
+                                        </Link>
+                                    </React.Fragment>
+                                )
+                            })}
+                        </div>
+                    </div>
+                    {currentNotebook && (
+                        <div className="hidden lg:flex items-center gap-1.5 ml-4 text-slate-400">
+                            <ChevronRightIcon className="h-4 w-4 flex-shrink-0" />
+                            <span className="text-sm font-medium text-slate-600 truncate max-w-[200px]">
+                                {currentNotebook.course_code}
+                            </span>
+                            <span className="text-slate-300">·</span>
+                            <span className="text-sm text-slate-500 truncate max-w-[240px]">
+                                {currentNotebook.title}
+                            </span>
+                        </div>
+                    )}
+
+                    <div className="flex items-center lg:hidden">
+                        <DisclosureButton className="group relative inline-flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-2 focus:-outline-offset-1 focus:outline-emerald-600">
+                            <span className="absolute -inset-0.5" />
+                            <span className="sr-only">Open navigation menu</span>
+                            <Bars3Icon aria-hidden="true" className="block size-6 group-data-open:hidden" />
+                            <XMarkIcon aria-hidden="true" className="hidden size-6 group-data-open:block" />
+                        </DisclosureButton>
+                    </div>
+                    <div className="hidden lg:ml-4 lg:flex lg:items-center lg:gap-3">
+                        {token ? <FocusToggle /> : null}
+                        <SettingsDropdown />
+
+                        {token ? (
+                            <div className="ml-1 flex items-center gap-2">
+                                <span className="flex size-8 items-center justify-center rounded-full bg-emerald-600 text-sm font-medium text-white outline -outline-offset-1 outline-black/10 overflow-hidden">
+                                    {avatarUrl
+                                        ? <img src={avatarUrl} alt="Avatar" className="w-full h-full object-cover" />
+                                        : displayInitial
+                                    }
+                                </span>
+                                <span className="max-w-[10rem] truncate text-sm font-medium text-gray-800">
+                                    {username || 'Signed in'}
+                                </span>
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-2">
+                                <Link
+                                    href="/"
+                                    className="cursor-pointer rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-white/50 hover:text-gray-900"
+                                >
+                                    Sign in
+                                </Link>
+                                <Link
+                                    href="/register"
+                                    className="cursor-pointer rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+                                >
+                                    Register
+                                </Link>
+                            </div>
+                        )}
+                    </div>
                 </div>
-              </div>
-              <div className="mt-3 space-y-1 px-2">
-                <DisclosureButton
-                  type="button"
-                  onClick={handleLogout}
-                  className="block w-full rounded-md px-4 py-2 text-left text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800"
-                >
-                  Sign out
-                </DisclosureButton>
-              </div>
-            </>
-          ) : (
-            <div className="space-y-2 px-4">
-              <DisclosureButton
-                as={Link}
-                href="/login"
-                className="block w-full rounded-md border border-gray-200 px-4 py-2 text-center text-base font-medium text-gray-800 hover:bg-gray-50"
-              >
-                Sign in
-              </DisclosureButton>
-              <DisclosureButton
-                as={Link}
-                href="/register"
-                className="block w-full rounded-md bg-emerald-600 px-4 py-2 text-center text-base font-medium text-white hover:bg-emerald-700"
-              >
-                Register
-              </DisclosureButton>
             </div>
-          )}
-        </div>
-      </DisclosurePanel>
-    </Disclosure>
-  )
+
+            <DisclosurePanel className="border-t border-gray-200 lg:hidden">
+                <NavMenuPanel {...panelProps} />
+            </DisclosurePanel>
+        </Disclosure>
+    )
 }

--- a/frontend/src/components/NotebookCard.tsx
+++ b/frontend/src/components/NotebookCard.tsx
@@ -62,7 +62,7 @@ export default function NotebookCard({ notebook, onDelete, isDeleting = false }:
   };
 
   return (
-    <div className="glass-panel flex flex-col overflow-hidden shadow-sm transition-shadow hover:shadow-md">
+    <div className="border rounded-lg glass-panel flex flex-col overflow-hidden shadow-sm transition-shadow hover:shadow-md">
       {/* Header — banner image or gradient, with hover upload overlay */}
       <div className="relative group h-24 overflow-hidden">
         <Link href={`/backpack/${notebook.id}/notes`} className="block w-full h-full">

--- a/frontend/src/components/SettingsDropdown.tsx
+++ b/frontend/src/components/SettingsDropdown.tsx
@@ -102,7 +102,7 @@ export default function SettingsDropdown() {
       <button
         type="button"
         onClick={() => { setOpen((v) => !v); if (open) { setThemeExpanded(false); setAccountExpanded(false) } }}
-        className="relative flex items-center justify-center rounded-full p-1 text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-emerald-600"
+        className="relative flex cursor-pointer items-center justify-center rounded-full p-1 text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-emerald-600"
         aria-label="Open settings"
       >
         <span className="absolute -inset-1.5" />
@@ -116,7 +116,7 @@ export default function SettingsDropdown() {
           <button
             type="button"
             onClick={() => setThemeExpanded((v) => !v)}
-            className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-white/20 transition-colors"
+            className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/20"
           >
             <SwatchIcon className="size-4 text-slate-500 flex-shrink-0" />
             <span className="flex-1 text-sm font-medium text-slate-700">Theme</span>
@@ -130,7 +130,7 @@ export default function SettingsDropdown() {
                   key={id}
                   type="button"
                   onClick={() => setTheme(id)}
-                  className={`flex items-center gap-3 w-full px-3 py-2 rounded-lg text-left transition-colors ${
+                  className={`flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors ${
                     theme === id ? 'bg-emerald-50/60' : 'hover:bg-white/30'
                   }`}
                 >
@@ -152,7 +152,7 @@ export default function SettingsDropdown() {
           <button
             type="button"
             onClick={() => setAccountExpanded((v) => !v)}
-            className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-white/20 transition-colors"
+            className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/20"
           >
             <UserCircleIcon className="size-4 text-slate-500 flex-shrink-0" />
             <span className="flex-1 text-sm font-medium text-slate-700">Account settings</span>
@@ -192,7 +192,7 @@ export default function SettingsDropdown() {
                     type="button"
                     onClick={handleRemoveAvatar}
                     disabled={!blobUrl || uploading}
-                    className="text-xs text-slate-400 hover:text-red-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                    className="cursor-pointer text-xs text-slate-400 transition-colors hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-40"
                   >
                     Remove photo
                   </button>
@@ -203,7 +203,7 @@ export default function SettingsDropdown() {
               <button
                 type="button"
                 onClick={handleLogout}
-                className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm text-red-600 hover:bg-red-50/60 transition-colors"
+                className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm text-red-600 transition-colors hover:bg-red-50/60"
               >
                 <ArrowRightStartOnRectangleIcon className="size-4 flex-shrink-0" />
                 Sign out

--- a/frontend/src/components/icons/BackpackIcon.tsx
+++ b/frontend/src/components/icons/BackpackIcon.tsx
@@ -1,0 +1,19 @@
+import { forwardRef, type SVGProps } from 'react';
+
+const BackpackIcon = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(
+    function BackpackIcon({ className, ...props }, ref) {
+        return (
+            <svg width="30" height="30" viewBox="0 0 200 200" fill="none" stroke="currentColor" strokeWidth="6" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
+            // Main backpack body
+                <rect x="50" y="60" width="100" height="100" rx="15" />
+                <path d="M50 100 Q50 40 100 40 Q150 40 150 100" />
+                //  Handle
+                <ellipse cx="100" cy="40" rx="15" ry="13" />
+                // Front pocket
+                <rect x="75" y="110" width="50" height="40" rx="8" />
+            </svg>
+        );
+    }
+);
+
+export default BackpackIcon;

--- a/frontend/src/components/icons/PomodoroIcon.tsx
+++ b/frontend/src/components/icons/PomodoroIcon.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, type SVGProps } from 'react';
+
+/**
+ * Stylized tomato outline for Pomodoro — matches @heroicons/react/24/outline (stroke 1.5, round caps).
+ */
+const PomodoroIcon = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(
+  function PomodoroIcon({ className, ...props }, ref) {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className={className}
+        ref={ref}
+        aria-hidden
+        {...props}
+      >
+        {/* Stem */}
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 4.25V2.75M10.25 3.5c.35-.65.9-1 1.75-1s1.4.35 1.75 1"
+        />
+        {/* Body */}
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 5.25c-4.6 0-7.75 3.35-7.75 7.35 0 4.25 3.5 7.65 7.75 7.65s7.75-3.4 7.75-7.65c0-4-3.15-7.35-7.75-7.35Z"
+        />
+      </svg>
+    );
+  }
+);
+
+export default PomodoroIcon;

--- a/frontend/src/components/study/AmbientAudioPlayer.tsx
+++ b/frontend/src/components/study/AmbientAudioPlayer.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { setAmbientTrack, setAmbientMasterVolume, stopAmbient, type AmbientTrack } from '../../lib/study/ambientEngine';
+
+const OPTIONS: { id: AmbientTrack; label: string }[] = [
+  { id: 'off', label: 'Off' },
+  { id: 'lofi', label: 'Lo-fi' },
+  { id: 'rain', label: 'Rain' },
+  { id: 'white', label: 'White' },
+];
+
+export default function AmbientAudioPlayer() {
+  const [track, setTrack] = useState<AmbientTrack>('off');
+  const [volume, setVolume] = useState(45);
+
+  useEffect(() => {
+    setAmbientTrack(track, volume / 100);
+  }, [track]);
+
+  useEffect(() => {
+    if (track === 'off') return;
+    setAmbientMasterVolume(volume / 100);
+  }, [volume, track]);
+
+  useEffect(() => {
+    return () => stopAmbient();
+  }, []);
+
+  return (
+    <div className="border-t border-white/20 px-3 py-3">
+      <p className="mb-2 text-center text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+        Ambient
+      </p>
+      <div className="flex flex-wrap justify-center gap-1">
+        {OPTIONS.map(({ id, label }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setTrack(id)}
+            className={`cursor-pointer rounded-md px-2 py-1 text-[11px] font-medium transition-colors ${
+              track === id
+                ? 'bg-emerald-600 text-white'
+                : 'bg-white/25 text-slate-700 hover:bg-white/40'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="mt-3 flex items-center gap-2">
+        <span className="shrink-0 text-[10px] text-slate-500">Vol</span>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          value={volume}
+          onChange={(e) => setVolume(Number(e.target.value))}
+          className="h-1.5 flex-1 cursor-pointer accent-emerald-600"
+          aria-label="Ambient volume"
+        />
+        <span className="w-7 shrink-0 text-right font-mono text-[10px] text-slate-600">{volume}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/study/DraggableFloatingWidget.tsx
+++ b/frontend/src/components/study/DraggableFloatingWidget.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 
 type Position = { left: number; top: number };
 
@@ -20,6 +21,8 @@ type Props = {
   defaultTop?: number;
   defaultRight?: number;
   className?: string;
+  /** Typically exits focus mode so the navbar returns. */
+  onClose?: () => void;
 };
 
 export default function DraggableFloatingWidget({
@@ -28,6 +31,7 @@ export default function DraggableFloatingWidget({
   defaultTop = 72,
   defaultRight = 16,
   className = '',
+  onClose,
 }: Props) {
   const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -68,9 +72,12 @@ export default function DraggableFloatingWidget({
     );
   }, [storageKey, defaultTop, defaultRight]);
 
+  // Re-run when `portalEl` becomes available: first effect pass runs before the portaled
+  // shell exists, so `rootRef` is null until after `document.body` is set — without
+  // `portalEl` in deps, position would stay null and the widget would stay invisible.
   useLayoutEffect(() => {
     measureAndPlace();
-  }, [measureAndPlace]);
+  }, [portalEl, measureAndPlace]);
 
   useEffect(() => {
     function onResize() {
@@ -143,19 +150,34 @@ export default function DraggableFloatingWidget({
           : { left: 0, top: 0 }
       }
     >
-      <div
-        className="flex cursor-grab touch-none select-none items-center justify-center gap-0.5 border-b border-white/25 bg-white/15 py-2 active:cursor-grabbing"
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-        aria-label="Drag to move timer"
-      >
-        <span className="flex gap-1 rounded-sm px-2 py-0.5">
-          {[0, 1, 2, 3, 4, 5].map((i) => (
-            <span key={i} className="h-1 w-1 rounded-full bg-slate-400/90" />
-          ))}
-        </span>
+      <div className="flex min-h-[2.5rem] touch-none select-none items-stretch border-b border-white/25 bg-white/15">
+        <div
+          className="flex flex-1 cursor-grab items-center justify-center gap-0.5 py-2 active:cursor-grabbing"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          aria-label="Drag to move study tools"
+        >
+          <span className="flex gap-1 rounded-sm px-2 py-0.5">
+            {[0, 1, 2, 3, 4, 5].map((i) => (
+              <span key={i} className="h-1 w-1 rounded-full bg-slate-400/90" />
+            ))}
+          </span>
+        </div>
+        {onClose ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            className="flex shrink-0 items-center justify-center border-l border-white/20 px-2.5 text-slate-500 transition-colors hover:bg-white/20 hover:text-slate-800"
+            aria-label="Exit focus mode"
+          >
+            <XMarkIcon className="h-5 w-5" aria-hidden />
+          </button>
+        ) : null}
       </div>
       <div className="min-w-0">{children}</div>
     </div>

--- a/frontend/src/components/study/DraggableFloatingWidget.tsx
+++ b/frontend/src/components/study/DraggableFloatingWidget.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type Position = { left: number; top: number };
+
+function clampPos(pos: Position, width: number, height: number, margin = 8): Position {
+  if (typeof window === 'undefined') return pos;
+  return {
+    left: Math.min(Math.max(margin, pos.left), Math.max(margin, window.innerWidth - width - margin)),
+    top: Math.min(Math.max(margin, pos.top), Math.max(margin, window.innerHeight - height - margin)),
+  };
+}
+
+type Props = {
+  children: React.ReactNode;
+  /** Persist position in localStorage (per notebook view). */
+  storageKey?: string;
+  defaultTop?: number;
+  defaultRight?: number;
+  className?: string;
+};
+
+export default function DraggableFloatingWidget({
+  children,
+  storageKey = 'notebud-study-widget-pos',
+  defaultTop = 72,
+  defaultRight = 16,
+  className = '',
+}: Props) {
+  const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ startX: number; startY: number; origin: Position } | null>(null);
+  const [position, setPosition] = useState<Position | null>(null);
+
+  useLayoutEffect(() => {
+    setPortalEl(document.body);
+  }, []);
+
+  const measureAndPlace = useCallback(() => {
+    const el = rootRef.current;
+    if (!el || typeof window === 'undefined') return;
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+
+    if (storageKey) {
+      try {
+        const raw = localStorage.getItem(storageKey);
+        if (raw) {
+          const p = JSON.parse(raw) as Position;
+          if (typeof p.left === 'number' && typeof p.top === 'number') {
+            setPosition(clampPos(p, w, h));
+            return;
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+
+    setPosition(
+      clampPos(
+        { left: window.innerWidth - w - defaultRight, top: defaultTop },
+        w,
+        h,
+      ),
+    );
+  }, [storageKey, defaultTop, defaultRight]);
+
+  useLayoutEffect(() => {
+    measureAndPlace();
+  }, [measureAndPlace]);
+
+  useEffect(() => {
+    function onResize() {
+      const el = rootRef.current;
+      if (!el) return;
+      setPosition((prev) => {
+        if (!prev) return prev;
+        return clampPos(prev, el.offsetWidth, el.offsetHeight);
+      });
+    }
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  useEffect(() => {
+    if (!storageKey || !position) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(position));
+    } catch {
+      /* ignore */
+    }
+  }, [storageKey, position]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (!position) return;
+    e.preventDefault();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      origin: { ...position },
+    };
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!dragRef.current || !rootRef.current) return;
+    const el = rootRef.current;
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const dx = e.clientX - dragRef.current.startX;
+    const dy = e.clientY - dragRef.current.startY;
+    setPosition(
+      clampPos(
+        {
+          left: dragRef.current.origin.left + dx,
+          top: dragRef.current.origin.top + dy,
+        },
+        w,
+        h,
+      ),
+    );
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    dragRef.current = null;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const shell = (
+    <div
+      ref={rootRef}
+      className={`fixed z-[100] flex flex-col overflow-hidden rounded-xl border border-white/30 shadow-lg backdrop-blur-[30px] ${position ? '' : 'invisible'} ${className}`}
+      style={
+        position
+          ? { left: position.left, top: position.top }
+          : { left: 0, top: 0 }
+      }
+    >
+      <div
+        className="flex cursor-grab touch-none select-none items-center justify-center gap-0.5 border-b border-white/25 bg-white/15 py-2 active:cursor-grabbing"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        aria-label="Drag to move timer"
+      >
+        <span className="flex gap-1 rounded-sm px-2 py-0.5">
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <span key={i} className="h-1 w-1 rounded-full bg-slate-400/90" />
+          ))}
+        </span>
+      </div>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+
+  if (!portalEl) return null;
+  return createPortal(shell, portalEl);
+}

--- a/frontend/src/components/study/FocusToggle.tsx
+++ b/frontend/src/components/study/FocusToggle.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import PomodoroIcon from '../icons/PomodoroIcon';
+import { useUiStore } from '../../lib/store/ui';
+
+export type FocusToggleProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** When set, shows text next to the icon (e.g. mobile menu row). */
+  label?: string;
+};
+
+/**
+ * Toggles `isFocusMode` in global UI state. No side effects beyond Zustand.
+ */
+const FocusToggle = forwardRef<HTMLButtonElement, FocusToggleProps>(function FocusToggle(
+  { className = '', label, type = 'button', onClick, ...props },
+  ref,
+) {
+  const isFocusMode = useUiStore((s) => s.isFocusMode);
+  const setIsFocusMode = useUiStore((s) => s.setIsFocusMode);
+
+  return (
+    <button
+      ref={ref}
+      type={type}
+      onClick={(e) => {
+        setIsFocusMode(!isFocusMode);
+        onClick?.(e);
+      }}
+      className={`inline-flex cursor-pointer items-center gap-2 rounded-md p-2 text-gray-500 hover:bg-white/50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 ${
+        isFocusMode ? 'text-emerald-600' : ''
+      } ${className}`}
+      aria-label={label ? undefined : 'Toggle focus mode'}
+      aria-pressed={isFocusMode}
+      {...props}
+    >
+      <PomodoroIcon className="pointer-events-none h-6 w-6 shrink-0" aria-hidden />
+      {label ? <span className="text-base font-medium">{label}</span> : null}
+    </button>
+  );
+});
+
+export default FocusToggle;

--- a/frontend/src/components/study/PomodoroTimer.tsx
+++ b/frontend/src/components/study/PomodoroTimer.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useReducer } from 'react';
+import { playPhaseChime } from '../../lib/study/phaseChime';
+
+const FOCUS_SECONDS = 25 * 60;
+const BREAK_SECONDS = 5 * 60;
+
+type Phase = 'focus' | 'break';
+type RunState = 'idle' | 'running' | 'paused';
+
+type State = {
+  phase: Phase;
+  remaining: number;
+  runState: RunState;
+};
+
+type Action =
+  | { type: 'TICK' }
+  | { type: 'START' }
+  | { type: 'PAUSE' }
+  | { type: 'RESET' };
+
+function formatMmSs(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'RESET':
+      return {
+        phase: 'focus',
+        remaining: FOCUS_SECONDS,
+        runState: 'idle',
+      };
+    case 'START':
+      if (state.runState === 'running') return state;
+      return { ...state, runState: 'running' };
+    case 'PAUSE':
+      if (state.runState !== 'running') return state;
+      return { ...state, runState: 'paused' };
+    case 'TICK': {
+      if (state.runState !== 'running') return state;
+
+      if (state.remaining > 1) {
+        return { ...state, remaining: state.remaining - 1 };
+      }
+      if (state.remaining === 1) {
+        return { ...state, remaining: 0 };
+      }
+      // remaining === 0: phase ended (user already saw 0:00 for 1s)
+      playPhaseChime();
+      if (state.phase === 'focus') {
+        return {
+          phase: 'break',
+          remaining: BREAK_SECONDS,
+          runState: 'running',
+        };
+      }
+      return {
+        phase: 'focus',
+        remaining: FOCUS_SECONDS,
+        runState: 'idle',
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+const initialState: State = {
+  phase: 'focus',
+  remaining: FOCUS_SECONDS,
+  runState: 'idle',
+};
+
+type PomodoroTimerProps = {
+  className?: string;
+};
+
+export default function PomodoroTimer({ className = '' }: PomodoroTimerProps) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    if (state.runState !== 'running') return;
+    const id = window.setInterval(() => dispatch({ type: 'TICK' }), 1000);
+    return () => window.clearInterval(id);
+  }, [state.runState]);
+
+  const label = state.phase === 'focus' ? 'Focus' : 'Break';
+
+  return (
+    <div
+      className={`glass-panel w-[min(100%,220px)] rounded-xl border border-white/30 px-4 py-3 shadow-sm backdrop-blur-[30px] ${className}`}
+    >
+      <p className="text-center text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 text-center font-mono text-3xl tabular-nums text-slate-800">{formatMmSs(state.remaining)}</p>
+      <div className="mt-3 flex flex-wrap justify-center gap-2">
+        {state.runState === 'running' ? (
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'PAUSE' })}
+            className="cursor-pointer rounded-lg bg-slate-200/80 px-3 py-1.5 text-sm font-medium text-slate-800 hover:bg-slate-300/90"
+          >
+            Pause
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'START' })}
+            className="cursor-pointer rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700"
+          >
+            Start
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => dispatch({ type: 'RESET' })}
+          className="cursor-pointer rounded-lg border border-white/40 bg-white/30 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-white/50"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/study/PomodoroTimer.tsx
+++ b/frontend/src/components/study/PomodoroTimer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useReducer } from 'react';
+import { useEffect, useReducer, type Dispatch } from 'react';
 import { playPhaseChime } from '../../lib/study/phaseChime';
 
 const FOCUS_SECONDS = 25 * 60;
@@ -9,25 +9,25 @@ const BREAK_SECONDS = 5 * 60;
 type Phase = 'focus' | 'break';
 type RunState = 'idle' | 'running' | 'paused';
 
-type State = {
+export type PomodoroState = {
   phase: Phase;
   remaining: number;
   runState: RunState;
 };
 
-type Action =
+type PomodoroAction =
   | { type: 'TICK' }
   | { type: 'START' }
   | { type: 'PAUSE' }
   | { type: 'RESET' };
 
-function formatMmSs(totalSeconds: number): string {
+export function formatMmSs(totalSeconds: number): string {
   const m = Math.floor(totalSeconds / 60);
   const s = totalSeconds % 60;
   return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
 }
 
-function reducer(state: State, action: Action): State {
+function reducer(state: PomodoroState, action: PomodoroAction): PomodoroState {
   switch (action.type) {
     case 'RESET':
       return {
@@ -50,7 +50,6 @@ function reducer(state: State, action: Action): State {
       if (state.remaining === 1) {
         return { ...state, remaining: 0 };
       }
-      // remaining === 0: phase ended (user already saw 0:00 for 1s)
       playPhaseChime();
       if (state.phase === 'focus') {
         return {
@@ -70,17 +69,13 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-const initialState: State = {
+const initialState: PomodoroState = {
   phase: 'focus',
   remaining: FOCUS_SECONDS,
   runState: 'idle',
 };
 
-type PomodoroTimerProps = {
-  className?: string;
-};
-
-export default function PomodoroTimer({ className = '' }: PomodoroTimerProps) {
+export function usePomodoroTimer() {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
@@ -89,6 +84,16 @@ export default function PomodoroTimer({ className = '' }: PomodoroTimerProps) {
     return () => window.clearInterval(id);
   }, [state.runState]);
 
+  return { state, dispatch };
+}
+
+type PomodoroTimerProps = {
+  className?: string;
+  state: PomodoroState;
+  dispatch: Dispatch<PomodoroAction>;
+};
+
+export default function PomodoroTimer({ className = '', state, dispatch }: PomodoroTimerProps) {
   const label = state.phase === 'focus' ? 'Focus' : 'Break';
 
   return (

--- a/frontend/src/components/study/StudyToolsPanel.tsx
+++ b/frontend/src/components/study/StudyToolsPanel.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
+import PomodoroTimer from './PomodoroTimer';
+import AmbientAudioPlayer from './AmbientAudioPlayer';
+
+type Props = {
+  /** Persist open/closed in localStorage (e.g. per notebook). */
+  storageKeyExpanded?: string;
+};
+
+export default function StudyToolsPanel({ storageKeyExpanded }: Props) {
+  const [expanded, setExpanded] = useState(true);
+
+  useEffect(() => {
+    if (!storageKeyExpanded || typeof window === 'undefined') return;
+    try {
+      const v = localStorage.getItem(storageKeyExpanded);
+      if (v === '0') setExpanded(false);
+      if (v === '1') setExpanded(true);
+    } catch {
+      /* ignore */
+    }
+  }, [storageKeyExpanded]);
+
+  useEffect(() => {
+    if (!storageKeyExpanded || typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(storageKeyExpanded, expanded ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  }, [expanded, storageKeyExpanded]);
+
+  return (
+    <div className="min-w-[220px]">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="flex w-full cursor-pointer items-center justify-between gap-2 border-b border-white/20 bg-white/10 px-3 py-2 text-left hover:bg-white/15"
+        aria-expanded={expanded}
+      >
+        <span className="text-xs font-semibold uppercase tracking-wide text-slate-600">Study tools</span>
+        {expanded ? (
+          <ChevronUpIcon className="h-4 w-4 shrink-0 text-slate-500" aria-hidden />
+        ) : (
+          <ChevronDownIcon className="h-4 w-4 shrink-0 text-slate-500" aria-hidden />
+        )}
+      </button>
+      <div className={expanded ? 'block' : 'hidden'}>
+        <PomodoroTimer className="w-full rounded-none border-0 shadow-none" />
+        <AmbientAudioPlayer />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/study/StudyToolsPanel.tsx
+++ b/frontend/src/components/study/StudyToolsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
-import PomodoroTimer from './PomodoroTimer';
+import PomodoroTimer, { formatMmSs, usePomodoroTimer } from './PomodoroTimer';
 import AmbientAudioPlayer from './AmbientAudioPlayer';
 
 type Props = {
@@ -12,6 +12,7 @@ type Props = {
 
 export default function StudyToolsPanel({ storageKeyExpanded }: Props) {
   const [expanded, setExpanded] = useState(true);
+  const { state: pomoState, dispatch: pomoDispatch } = usePomodoroTimer();
 
   useEffect(() => {
     if (!storageKeyExpanded || typeof window === 'undefined') return;
@@ -42,14 +43,25 @@ export default function StudyToolsPanel({ storageKeyExpanded }: Props) {
         aria-expanded={expanded}
       >
         <span className="text-xs font-semibold uppercase tracking-wide text-slate-600">Study tools</span>
-        {expanded ? (
-          <ChevronUpIcon className="h-4 w-4 shrink-0 text-slate-500" aria-hidden />
-        ) : (
-          <ChevronDownIcon className="h-4 w-4 shrink-0 text-slate-500" aria-hidden />
-        )}
+        <span className="flex min-w-0 flex-1 items-center justify-end gap-2">
+          {!expanded ? (
+            <span className="font-mono text-sm tabular-nums tracking-tight text-slate-800">
+              {formatMmSs(pomoState.remaining)}
+            </span>
+          ) : null}
+          {expanded ? (
+            <ChevronUpIcon className="h-4 w-4 shrink-0 text-slate-500" aria-hidden />
+          ) : (
+            <ChevronDownIcon className="h-4 w-4 shrink-0 text-slate-500" aria-hidden />
+          )}
+        </span>
       </button>
       <div className={expanded ? 'block' : 'hidden'}>
-        <PomodoroTimer className="w-full rounded-none border-0 shadow-none" />
+        <PomodoroTimer
+          state={pomoState}
+          dispatch={pomoDispatch}
+          className="w-full rounded-none border-0 shadow-none"
+        />
         <AmbientAudioPlayer />
       </div>
     </div>

--- a/frontend/src/lib/store/ui.ts
+++ b/frontend/src/lib/store/ui.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+type UiState = {
+  isFocusMode: boolean;
+  setIsFocusMode: (value: boolean) => void;
+};
+
+export const useUiStore = create<UiState>((set) => ({
+  isFocusMode: false,
+  setIsFocusMode: (value) => set({ isFocusMode: value }),
+}));
+

--- a/frontend/src/lib/study/ambientEngine.ts
+++ b/frontend/src/lib/study/ambientEngine.ts
@@ -3,6 +3,8 @@ export type AmbientTrack = 'off' | 'lofi' | 'rain' | 'white';
 let ctx: AudioContext | null = null;
 let master: GainNode | null = null;
 const stoppers: Array<() => void> = [];
+/** Invalidates in-flight `resume().then(...)` when a new `setAmbientTrack` runs. */
+let ambientGeneration = 0;
 
 function getAudioContext(): AudioContext {
   if (typeof window === 'undefined') {
@@ -83,33 +85,42 @@ function playRain(c: AudioContext, dest: AudioNode) {
   });
 }
 
-/** Simple soft pad (synth “lo-fi” vibe, no external files). */
+/**
+ * Soft pad (“lo-fi” vibe, no external files).
+ * Uses a looping buffer like white/rain so playback matches those code paths
+ * (OscillatorNode output can be silent until `AudioContext` has fully resumed).
+ * Integer Hz + 1s buffer so the loop seam stays phase-aligned.
+ */
 function playLofiPad(c: AudioContext, dest: AudioNode) {
-  const freqs = [130.81, 164.81, 196.0, 246.94]; // C3, E3, G3, B3
-  const oscillators: OscillatorNode[] = [];
-  const gains: GainNode[] = [];
-  for (const f of freqs) {
-    const osc = c.createOscillator();
-    osc.type = 'sine';
-    osc.frequency.value = f;
-    const g = c.createGain();
-    g.gain.value = 0.04;
-    osc.connect(g);
-    g.connect(dest);
-    osc.start();
-    oscillators.push(osc);
-    gains.push(g);
-  }
-  pushStop(() => {
-    for (const osc of oscillators) {
-      try {
-        osc.stop();
-      } catch {
-        /* ignore */
-      }
-      osc.disconnect();
+  const dur = 1;
+  const freqs = [110, 130, 165, 196];
+  const n = c.sampleRate * dur;
+  const buffer = c.createBuffer(1, n, c.sampleRate);
+  const ch = buffer.getChannelData(0);
+  for (let i = 0; i < n; i++) {
+    const t = i / c.sampleRate;
+    let s = 0;
+    for (const f of freqs) {
+      s += Math.sin(2 * Math.PI * f * t);
     }
-    for (const g of gains) g.disconnect();
+    ch[i] = s * 0.16;
+  }
+  const src = c.createBufferSource();
+  src.buffer = buffer;
+  src.loop = true;
+  const g = c.createGain();
+  g.gain.value = 0.38;
+  src.connect(g);
+  g.connect(dest);
+  src.start();
+  pushStop(() => {
+    try {
+      src.stop();
+    } catch {
+      /* ignore */
+    }
+    src.disconnect();
+    g.disconnect();
   });
 }
 
@@ -128,27 +139,36 @@ export function setAmbientMasterVolume(volume01: number): void {
 export function setAmbientTrack(track: AmbientTrack, volume01: number): void {
   if (typeof window === 'undefined') return;
 
+  const gen = ++ambientGeneration;
   const c = getAudioContext();
   clearSounds();
 
   if (!master) return;
 
-  void c.resume().catch(() => {});
+  const vol = Math.max(0, Math.min(1, volume01));
 
   if (track === 'off') {
     master.gain.value = 0;
+    void c.resume().catch(() => {});
     return;
   }
 
-  if (track === 'white') {
-    playWhiteNoise(c, master);
-  } else if (track === 'rain') {
-    playRain(c, master);
-  } else {
-    playLofiPad(c, master);
-  }
+  // Buffers + BufferSource must start after the context is running; a fire-and-forget
+  // `resume()` leaves `state === 'suspended'` long enough that playback is silent.
+  void c.resume().then(() => {
+    if (gen !== ambientGeneration) return;
+    if (!master) return;
 
-  setAmbientMasterVolume(volume01);
+    if (track === 'white') {
+      playWhiteNoise(c, master);
+    } else if (track === 'rain') {
+      playRain(c, master);
+    } else if (track === 'lofi') {
+      playLofiPad(c, master);
+    }
+
+    setAmbientMasterVolume(vol);
+  });
 }
 
 export function stopAmbient(): void {

--- a/frontend/src/lib/study/ambientEngine.ts
+++ b/frontend/src/lib/study/ambientEngine.ts
@@ -1,0 +1,158 @@
+export type AmbientTrack = 'off' | 'lofi' | 'rain' | 'white';
+
+let ctx: AudioContext | null = null;
+let master: GainNode | null = null;
+const stoppers: Array<() => void> = [];
+
+function getAudioContext(): AudioContext {
+  if (typeof window === 'undefined') {
+    throw new Error('Audio requires window');
+  }
+  if (!ctx) {
+    const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    ctx = new Ctor();
+    master = ctx.createGain();
+    master.gain.value = 0;
+    master.connect(ctx.destination);
+  }
+  return ctx;
+}
+
+function clearSounds() {
+  for (const s of stoppers) {
+    try {
+      s();
+    } catch {
+      /* ignore */
+    }
+  }
+  stoppers.length = 0;
+}
+
+function pushStop(fn: () => void) {
+  stoppers.push(fn);
+}
+
+/** White noise loop (~2s buffer). */
+function playWhiteNoise(c: AudioContext, dest: AudioNode) {
+  const dur = 2;
+  const n = c.sampleRate * dur;
+  const buffer = c.createBuffer(1, n, c.sampleRate);
+  const ch = buffer.getChannelData(0);
+  for (let i = 0; i < n; i++) ch[i] = Math.random() * 2 - 1;
+  const src = c.createBufferSource();
+  src.buffer = buffer;
+  src.loop = true;
+  const g = c.createGain();
+  g.gain.value = 0.35;
+  src.connect(g);
+  g.connect(dest);
+  src.start();
+  pushStop(() => {
+    src.stop();
+    src.disconnect();
+    g.disconnect();
+  });
+}
+
+/** Rain: filtered noise. */
+function playRain(c: AudioContext, dest: AudioNode) {
+  const dur = 2;
+  const n = c.sampleRate * dur;
+  const buffer = c.createBuffer(1, n, c.sampleRate);
+  const ch = buffer.getChannelData(0);
+  for (let i = 0; i < n; i++) ch[i] = Math.random() * 2 - 1;
+  const src = c.createBufferSource();
+  src.buffer = buffer;
+  src.loop = true;
+  const bp = c.createBiquadFilter();
+  bp.type = 'lowpass';
+  bp.frequency.value = 900;
+  bp.Q.value = 0.7;
+  const g = c.createGain();
+  g.gain.value = 0.45;
+  src.connect(bp);
+  bp.connect(g);
+  g.connect(dest);
+  src.start();
+  pushStop(() => {
+    src.stop();
+    src.disconnect();
+    bp.disconnect();
+    g.disconnect();
+  });
+}
+
+/** Simple soft pad (synth “lo-fi” vibe, no external files). */
+function playLofiPad(c: AudioContext, dest: AudioNode) {
+  const freqs = [130.81, 164.81, 196.0, 246.94]; // C3, E3, G3, B3
+  const oscillators: OscillatorNode[] = [];
+  const gains: GainNode[] = [];
+  for (const f of freqs) {
+    const osc = c.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = f;
+    const g = c.createGain();
+    g.gain.value = 0.04;
+    osc.connect(g);
+    g.connect(dest);
+    osc.start();
+    oscillators.push(osc);
+    gains.push(g);
+  }
+  pushStop(() => {
+    for (const osc of oscillators) {
+      try {
+        osc.stop();
+      } catch {
+        /* ignore */
+      }
+      osc.disconnect();
+    }
+    for (const g of gains) g.disconnect();
+  });
+}
+
+/**
+ * Live master level while a track is playing (0–1). No-op when off.
+ */
+export function setAmbientMasterVolume(volume01: number): void {
+  if (!master) return;
+  const v = Math.max(0, Math.min(1, volume01)) * 0.5;
+  master.gain.value = stoppers.length > 0 ? v : 0;
+}
+
+/**
+ * Sets ambient bed. Volume 0–1. Safe to call repeatedly; replaces previous sound.
+ */
+export function setAmbientTrack(track: AmbientTrack, volume01: number): void {
+  if (typeof window === 'undefined') return;
+
+  const c = getAudioContext();
+  clearSounds();
+
+  if (!master) return;
+
+  void c.resume().catch(() => {});
+
+  if (track === 'off') {
+    master.gain.value = 0;
+    return;
+  }
+
+  if (track === 'white') {
+    playWhiteNoise(c, master);
+  } else if (track === 'rain') {
+    playRain(c, master);
+  } else {
+    playLofiPad(c, master);
+  }
+
+  setAmbientMasterVolume(volume01);
+}
+
+export function stopAmbient(): void {
+  if (typeof window === 'undefined') return;
+  clearSounds();
+  if (master) master.gain.value = 0;
+}

--- a/frontend/src/lib/study/phaseChime.ts
+++ b/frontend/src/lib/study/phaseChime.ts
@@ -1,0 +1,30 @@
+/**
+ * Short soft chime when a Pomodoro phase ends. Uses Web Audio (no network).
+ * Call after a user gesture (e.g. Start) so AudioContext is allowed in strict browsers.
+ */
+export function playPhaseChime(): void {
+  if (typeof window === 'undefined') return;
+
+  const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return;
+
+  const ctx = new Ctor();
+  const t0 = ctx.currentTime;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(880, t0);
+  osc.frequency.exponentialRampToValueAtTime(660, t0 + 0.12);
+
+  gain.gain.setValueAtTime(0, t0);
+  gain.gain.linearRampToValueAtTime(0.1, t0 + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.001, t0 + 0.35);
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(t0);
+  osc.stop(t0 + 0.4);
+
+  void ctx.resume().catch(() => {});
+}


### PR DESCRIPTION
**Focus mode and study tools**
- Focus mode is driven by global UI state (isFocusMode in useUiStore). In focus mode the full navbar is replaced by a compact top overlay (menu + focus toggle); the notes workspace drops top padding (pt-0 vs pt-16) so content uses the full height.
- Study tools (Pomodoro, ambient audio, collapsible panel) live in a DraggableFloatingWidget portaled to document.body at z-[100] so it stays above the nav and isn’t clipped by main.
- The floating panel is only shown while focus mode is on, header 'X" exits focus mode (and does not persist a separate “widget closed” state); turning focus back on shows the panel again.
    
**Layout and flex**
- Notes layout uses flex + min-h-0 / h-full on main, the center column, and side panes so the three-column area fills the viewport without a dead band under the nav when focus mode is off.

**Draggable widget fix**
-  DraggableFloatingWidget: measuring/placing the widget re-runs when portalEl becomes document.body, so position is set after the portaled shell exists. Previously the measure effect could run once with no ref, leaving the widget invisible forever.

**Ambient audio**

   -  Ambient beds (white, rain, lo-fi) start after AudioContext.resume() resolves, with a generation counter so in-flight callbacks don’t apply after a newer setAmbientTrack or Off.
   - [Needs fix] Lo-fi is a looping buffer (soft chord pad), same family as white/rain, so it isn’t tied to oscillator/suspend quirks.
   - Pomodoro + study panel UX
   - `usePomodoroTimer` lifts timer state to StudyToolsPanel so when the panel is collapsed, MM:SS appears on the same row as “Study tools” and the chevron (expanded view keeps the full timer + controls below).

**Files touched**
- `frontend/src/lib/store/ui.ts, NavBar.tsx, FocusToggle.tsx`
- `frontend/src/app/backpack/[id]/notes/page.tsx`
- `frontend/src/components/study/` — DraggableFloatingWidget, StudyToolsPanel, PomodoroTimer, AmbientAudioPlayer, related icons
- `frontend/src/lib/study/ambientEngine.ts, phaseChime.ts`

**How to test**
- Open a notebook notes page → enable focus mode from the navbar → confirm full-width content, overlay nav, and study widget visible and draggable.
- Use X on the widget → focus mode off, normal navbar and padding return; enable focus again → widget returns.
- Ambient: try Lo-fi, Rain, White after a user gesture; change volume while a track plays.
- Study tools header: collapse the panel → time on one line with the title; expand → large timer + controls.
- Resize the window with the widget open → position stays on-screen.

