### PR TITLE
fix: hide plus icon on Cancel and minimize timer instead of reset

### DIFF
--- a/frontend/src/app/backpack/page.tsx
+++ b/frontend/src/app/backpack/page.tsx
@@ -204,7 +204,7 @@ export default function BackpackPage() {
                                 onClick={() => setShowCreateForm(!showCreateForm)}
                                 className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 transition-colors"
                             >
-                                <PlusIcon className="size-4" />
+                                {!showCreateForm && <PlusIcon className="size-4" />}
                                 {showCreateForm ? 'Cancel' : 'Create new'}
                             </button>
                         </div>

--- a/frontend/src/components/study/DraggableFloatingWidget.tsx
+++ b/frontend/src/components/study/DraggableFloatingWidget.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 
 type Position = { left: number; top: number };
 
@@ -37,6 +37,7 @@ export default function DraggableFloatingWidget({
   const rootRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ startX: number; startY: number; origin: Position } | null>(null);
   const [position, setPosition] = useState<Position | null>(null);
+  const [minimized, setMinimized] = useState(false);
 
   useLayoutEffect(() => {
     setPortalEl(document.body);
@@ -165,21 +166,19 @@ export default function DraggableFloatingWidget({
             ))}
           </span>
         </div>
-        {onClose ? (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            className="flex shrink-0 items-center justify-center border-l border-white/20 px-2.5 text-slate-500 transition-colors hover:bg-white/20 hover:text-slate-800"
-            aria-label="Exit focus mode"
-          >
-            <XMarkIcon className="h-5 w-5" aria-hidden />
-          </button>
-        ) : null}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setMinimized((m) => !m);
+          }}
+          className="flex shrink-0 items-center justify-center border-l border-white/20 px-2.5 text-slate-500 transition-colors hover:bg-white/20 hover:text-slate-800"
+          aria-label={minimized ? 'Expand study tools' : 'Minimize study tools'}
+        >
+          {minimized ? <ChevronUpIcon className="h-5 w-5" aria-hidden /> : <XMarkIcon className="h-5 w-5" aria-hidden />}
+        </button>
       </div>
-      <div className="min-w-0">{children}</div>
+      <div className={minimized ? 'hidden' : 'min-w-0'}>{children}</div>
     </div>
   );
 


### PR DESCRIPTION
## Summary
- **Backpack page**: Hide the `+` icon when the create button shows "Cancel" — previously showed `+ Cancel`
- **Study tools widget**: X button now minimizes the panel (hides content) instead of exiting focus mode entirely, so the pomodoro timer keeps running in the background. Click the chevron to expand again.

## Test plan
- [ ] Go to `/backpack`, click "Create new" — button should show "Cancel" without the plus icon
- [ ] Open a notebook's notes page, enter focus mode, start the pomodoro timer
- [ ] Click X on the floating widget — it should collapse but the timer should keep counting
- [ ] Click the chevron to expand — timer should still be running where it left off